### PR TITLE
Parser improvements

### DIFF
--- a/parser/event_types.go
+++ b/parser/event_types.go
@@ -15,6 +15,7 @@ var events = map[string]func() Parseable{
 	"jdk.InitialSystemProperty": func() Parseable { return new(InitialSystemProperty) },
 	// TODO: jdk.JavaMonitorEnter
 	"jdk.JVMInformation":              func() Parseable { return new(JVMInformation) },
+	"jdk.NativeLibrary":               func() Parseable { return new(NativeLibrary) },
 	"jdk.ObjectAllocationInNewTLAB":   func() Parseable { return new(ObjectAllocationInNewTLAB) },
 	"jdk.ObjectAllocationOutsideTLAB": func() Parseable { return new(ObjectAllocationOutsideTLAB) },
 	"jdk.OSInformation":               func() Parseable { return new(OSInformation) },
@@ -258,6 +259,31 @@ func (ji *JVMInformation) parseField(name string, p ParseResolvable) (err error)
 
 func (ji *JVMInformation) Parse(r reader.Reader, classes ClassMap, cpools PoolMap, class ClassMetadata) error {
 	return parseFields(r, classes, cpools, class, nil, true, ji.parseField)
+}
+
+type NativeLibrary struct {
+	StartTime   int64
+	Name        string
+	BaseAddress int64
+	TopAddress  int64
+}
+
+func (nl *NativeLibrary) parseField(name string, p ParseResolvable) (err error) {
+	switch name {
+	case "startTime":
+		nl.StartTime, err = toLong(p)
+	case "name":
+		nl.Name, err = toString(p)
+	case "baseAddress":
+		nl.BaseAddress, err = toLong(p)
+	case "topAddress":
+		nl.TopAddress, err = toLong(p)
+	}
+	return err
+}
+
+func (nl *NativeLibrary) Parse(r reader.Reader, classes ClassMap, cpools PoolMap, class ClassMetadata) error {
+	return parseFields(r, classes, cpools, class, nil, true, nl.parseField)
 }
 
 type ObjectAllocationInNewTLAB struct {

--- a/parser/types.go
+++ b/parser/types.go
@@ -92,7 +92,7 @@ func parseFields(r reader.Reader, classes ClassMap, cpools PoolMap, class ClassM
 				}
 				p, ok := cpool[int(i)]
 				if !ok {
-					return fmt.Errorf("unknown constant pool index %d for class %d", i, f.Class)
+					continue
 				}
 				if err := cb(f.Name, p); err != nil {
 					return fmt.Errorf("unable to parse constant field %s: %w", f.Name, err)

--- a/parser/types.go
+++ b/parser/types.go
@@ -34,11 +34,12 @@ func ParseClass(r reader.Reader, classes ClassMap, cpools PoolMap, classID int64
 	if !ok {
 		return nil, fmt.Errorf("unexpected class %d", classID)
 	}
-	typeFn, ok := types[class.Name]
-	if !ok {
-		return nil, fmt.Errorf("unknown type %s", class.Name)
+	var v ParseResolvable
+	if typeFn, ok := types[class.Name]; ok {
+		v = typeFn()
+	} else {
+		v = new(UnsupportedType)
 	}
-	v := typeFn()
 	if err := v.Parse(r, classes, cpools, class); err != nil {
 		return nil, err
 	}
@@ -683,4 +684,23 @@ func toSymbol(p ParseResolvable) (*Symbol, error) {
 		return nil, errors.New("")
 	}
 	return s, nil
+}
+
+// UnsupportedType represents any type that is not supported by the parser.
+// This will allow to still read the unsupported type instead of returning an error.
+type UnsupportedType struct {
+	constants []constant
+	resolved  bool
+}
+
+func (ut *UnsupportedType) parseField(name string, p ParseResolvable) error {
+	return nil
+}
+
+func (ut *UnsupportedType) Parse(r reader.Reader, classes ClassMap, cpools PoolMap, class ClassMetadata) error {
+	return parseFields(r, classes, cpools, class, &ut.constants, ut.resolved, ut.parseField)
+}
+
+func (ut *UnsupportedType) Resolve(classes ClassMap, cpools PoolMap) error {
+	return resolveConstants(classes, cpools, &ut.constants, &ut.resolved, ut.parseField)
 }


### PR DESCRIPTION
- Add fallback implementations for unsupported (event) types. These generic implementations allow the parser to read and ignore
these unsupported types instead of just returning a parsing error.
- Ignore non-existing constant pool references
- Add support for Native Library event type.

Related to #4 