### PR TITLE
Add cpool preprocessor parse option

### DIFF
--- a/parser/checkpoint.go
+++ b/parser/checkpoint.go
@@ -41,7 +41,7 @@ func (c *CheckpointEvent) Parse(r reader.Reader, classes ClassMap, cpools PoolMa
 		}
 		cm, ok := cpools[int(classID)]
 		if !ok {
-			cpools[int(classID)] = &CPool{pool: make(map[int]ParseResolvable)}
+			cpools[int(classID)] = &CPool{Pool: make(map[int]ParseResolvable)}
 			cm = cpools[int(classID)]
 		}
 		m, err := r.VarInt()
@@ -58,7 +58,7 @@ func (c *CheckpointEvent) Parse(r reader.Reader, classes ClassMap, cpools PoolMa
 			if err != nil {
 				return fmt.Errorf("unable to parse constant type %d: %w", classID, err)
 			}
-			cm.pool[int(idx)] = v
+			cm.Pool[int(idx)] = v
 		}
 	}
 	return nil

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -6,10 +6,14 @@ import (
 )
 
 func Parse(r io.Reader) ([]Chunk, error) {
+	return ParseWithOptions(r, &ChunkParseOptions{})
+}
+
+func ParseWithOptions(r io.Reader, options *ChunkParseOptions) ([]Chunk, error) {
 	var chunks []Chunk
 	for {
 		var chunk Chunk
-		err := chunk.Parse(r)
+		err := chunk.Parse(r, options)
 		if err == io.EOF {
 			return chunks, nil
 		}

--- a/parser/types.go
+++ b/parser/types.go
@@ -97,7 +97,7 @@ func parseFields(r reader.Reader, classes ClassMap, cpools PoolMap, class ClassM
 				if err != nil {
 					return fmt.Errorf("unable to read constant index")
 				}
-				p, ok := cpool.pool[int(i)]
+				p, ok := cpool.Pool[int(i)]
 				if !ok {
 					continue
 				}
@@ -147,7 +147,7 @@ func resolveConstants(classes ClassMap, cpools PoolMap, constants *[]constant, r
 			// Non-existent constant pool references seem to be used to mark no value
 			continue
 		}
-		it, ok := p.pool[int(c.index)]
+		it, ok := p.Pool[int(c.index)]
 		if !ok {
 			// Non-existent constant pool references seem to be used to mark no value
 			continue


### PR DESCRIPTION
This will allow to do some modifications(for example do a bunch of regex replace https://github.com/pyroscope-io/pyroscope/pull/1149) to constants before they are resolved to events.