### PR TITLE
fix string and bytes convert use large memory

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/pyroscope-io/jfr-parser
 
-go 1.16
+go 1.20

--- a/parser/checkpoint.go
+++ b/parser/checkpoint.go
@@ -59,10 +59,6 @@ func (c *CheckpointEvent) Parse(r reader.Reader, classes ClassMap, cpools PoolMa
 				return fmt.Errorf("unable to parse constant type %d: %w", classID, err)
 			}
 			cm.Pool[int(idx)] = v
-			if p, ok := v.(*StackFrame); ok {
-				p.reset()
-				stackFramePool.Put(p)
-			}
 		}
 	}
 	return nil

--- a/parser/checkpoint.go
+++ b/parser/checkpoint.go
@@ -59,6 +59,10 @@ func (c *CheckpointEvent) Parse(r reader.Reader, classes ClassMap, cpools PoolMa
 				return fmt.Errorf("unable to parse constant type %d: %w", classID, err)
 			}
 			cm.Pool[int(idx)] = v
+			if p, ok := v.(*StackFrame); ok {
+				p.reset()
+				stackFramePool.Put(p)
+			}
 		}
 	}
 	return nil

--- a/parser/metadata.go
+++ b/parser/metadata.go
@@ -205,11 +205,11 @@ func (m *MetadataEvent) Parse(r reader.Reader) (err error) {
 	// TODO: assert n is small enough
 	strings := make([]string, n)
 	for i := 0; i < int(n); i++ {
-		bytes, err := r.Bytes()
+		s, err := r.String()
 		if err != nil {
 			return fmt.Errorf("unable to parse metadata event's string: %w", err)
 		}
-		strings[i] = string(bytes2String(bytes))
+		strings[i] = s
 	}
 
 	name, err := parseName(r, strings)

--- a/parser/metadata.go
+++ b/parser/metadata.go
@@ -205,9 +205,11 @@ func (m *MetadataEvent) Parse(r reader.Reader) (err error) {
 	// TODO: assert n is small enough
 	strings := make([]string, n)
 	for i := 0; i < int(n); i++ {
-		if strings[i], err = r.String(); err != nil {
+		bytes, err := r.Bytes()
+		if err != nil {
 			return fmt.Errorf("unable to parse metadata event's string: %w", err)
 		}
+		strings[i] = string(bytes2String(bytes))
 	}
 
 	name, err := parseName(r, strings)

--- a/reader/b2s_new.go
+++ b/reader/b2s_new.go
@@ -1,0 +1,12 @@
+//go:build go1.20
+// +build go1.20
+
+package reader
+
+import "unsafe"
+
+// b2s converts byte slice to a string without memory allocation.
+// See https://groups.google.com/forum/#!msg/Golang-Nuts/ENgbUzYvCuU/90yGx7GUAgAJ .
+func b2s(b []byte) string {
+	return unsafe.String(unsafe.SliceData(b), len(b))
+}

--- a/reader/b2s_old.go
+++ b/reader/b2s_old.go
@@ -1,0 +1,16 @@
+//go:build !go1.20
+// +build !go1.20
+
+package reader
+
+import "unsafe"
+
+// b2s converts byte slice to a string without memory allocation.
+// See https://groups.google.com/forum/#!msg/Golang-Nuts/ENgbUzYvCuU/90yGx7GUAgAJ .
+//
+// Note it may break if string and/or slice header will change
+// in the future go versions.
+func b2s(b []byte) string {
+	/* #nosec G103 */
+	return *(*string)(unsafe.Pointer(&b))
+}


### PR DESCRIPTION
jfr-parser consumes a lot of memory when processing large chunk files.

Part of the reason is that the read module has a lot of []byte and string interconversions.