### PR TITLE
Bump jfr-parser version

### DIFF
--- a/pprof/go.mod
+++ b/pprof/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/google/pprof v0.0.0-20240727154555-813a5fbdbec8
-	github.com/grafana/jfr-parser v0.9.1
+	github.com/grafana/jfr-parser v0.9.2
 	github.com/grafana/pyroscope/api v0.4.0
 	github.com/k0kubun/pp/v3 v3.2.0
 	github.com/stretchr/testify v1.9.0

--- a/pprof/go.sum
+++ b/pprof/go.sum
@@ -3,8 +3,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/pprof v0.0.0-20240727154555-813a5fbdbec8 h1:FKHo8hFI3A+7w0aUQuYXQ+6EN5stWmeY/AZqtM8xk9k=
 github.com/google/pprof v0.0.0-20240727154555-813a5fbdbec8/go.mod h1:K1liHPHnj73Fdn/EKuT8nrFqBihUSKXoLYU0BuatOYo=
-github.com/grafana/jfr-parser v0.9.1 h1:AjV1s9/2SS1jGmNyJ0+w+nl8tPr0KWM55ClBfQTcKjQ=
-github.com/grafana/jfr-parser v0.9.1/go.mod h1:KYbwbvXtBoOsYw9b9w8R01dbM5oVfopljq3hA1WDJMQ=
+github.com/grafana/jfr-parser v0.9.2 h1:Ba6hqld0oWAIcaY06K7c5DopnsVcAwXhRGS2zGbkDM0=
+github.com/grafana/jfr-parser v0.9.2/go.mod h1:KYbwbvXtBoOsYw9b9w8R01dbM5oVfopljq3hA1WDJMQ=
 github.com/grafana/pyroscope/api v0.4.0 h1:J86DxoNeLOvtJhB1Cn65JMZkXe682D+RqeoIUiYc/eo=
 github.com/grafana/pyroscope/api v0.4.0/go.mod h1:MFnZNeUM4RDsDOnbgKW3GWoLSBpLzMMT9nkvhHHo81o=
 github.com/k0kubun/pp/v3 v3.2.0 h1:h33hNTZ9nVFNP3u2Fsgz8JXiF5JINoZfFq4SvKJwNcs=


### PR DESCRIPTION
The current dependecy version was too old

```
{ cd ./pprof && GOWORK=off go test ./... }
./parser.go:53:23: parser.TypeMap.T_ALLOC_SAMPLE undefined (type def.TypeMap has no field or method T_ALLOC_SAMPLE)
./parser.go:54:29: parser.ObjectAllocationSample undefined (type *parser.Parser has no field or method ObjectAllocationSample)
./parser.go:55:57: parser.ObjectAllocationSample undefined (type *parser.Parser has no field or method ObjectAllocationSample)
FAIL    github.com/grafana/jfr-parser/pprof [build failed]
FAIL    github.com/grafana/jfr-parser/pprof/cmd/jfrparser [build failed]
FAIL    github.com/grafana/jfr-parser/pprof/cmd/jfrparser/format [build failed]
?       github.com/grafana/jfr-parser/pprof/pyroscope   [no test files]
FAIL
```
