### PR TITLE
Check that outside of the goworkspace, dependcies are uptodate

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,3 +19,7 @@ jobs:
       - name: Run tests
         run: |
           make test
+      - name: Check that ./pprof's dependcies do work, at main
+        run: |
+          make test-dependency
+        if: ${{ github.ref == 'refs/heads/main' }}

--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,8 @@ TEST_PACKAGES := ./... ./pprof/...
 .PHONY: test
 test:
 	go test -race $(shell go list $(TEST_PACKAGES))
+
+# Test if dependencies are up to date, without go workspaces pinning
+.PHONY: test-dependency
+test-dependency:
+	cd ./pprof && GOWORK=off go test ./...


### PR DESCRIPTION
This would make sure we catch #46, but it would also require for breaking changes to be split in two. Not too sure maybe we only check this on push to main?