### PR TITLE
feat: Add span correlation support for WallClockSample events

### DIFF
--- a/internal/cmd/gen/types.go
+++ b/internal/cmd/gen/types.go
@@ -322,6 +322,9 @@ var Type_profiler_WallClockSample = def.Class{
 		{Name: "sampledThread", Type: T_THREAD, ConstantPool: true},
 		{Name: "stackTrace", Type: T_STACK_TRACE, ConstantPool: true},
 		{Name: "state", Type: T_THREAD_STATE, ConstantPool: true},
+		{Name: "spanId", Type: T_LONG, ConstantPool: false},
+		{Name: "spanName", Type: T_LONG, ConstantPool: false},
+		{Name: "contextId", Type: T_LONG, ConstantPool: false},
 		{Name: "samples", Type: T_INT, ConstantPool: false},
 	},
 }

--- a/parser/types/wall_clock_sample.go
+++ b/parser/types/wall_clock_sample.go
@@ -52,6 +52,24 @@ func NewBindWallClockSample(typ *def.Class, typeMap *def.TypeMap) *BindWallClock
 			} else {
 				res.Fields = append(res.Fields, BindFieldWallClockSample{Field: &typ.Fields[i]}) // skip changed field
 			}
+		case "spanId":
+			if typ.Fields[i].Equals(&def.Field{Name: "spanId", Type: typeMap.T_LONG, ConstantPool: false, Array: false}) {
+				res.Fields = append(res.Fields, BindFieldWallClockSample{Field: &typ.Fields[i], uint64: &res.Temp.SpanId})
+			} else {
+				res.Fields = append(res.Fields, BindFieldWallClockSample{Field: &typ.Fields[i]}) // skip changed field
+			}
+		case "spanName":
+			if typ.Fields[i].Equals(&def.Field{Name: "spanName", Type: typeMap.T_LONG, ConstantPool: false, Array: false}) {
+				res.Fields = append(res.Fields, BindFieldWallClockSample{Field: &typ.Fields[i], uint64: &res.Temp.SpanName})
+			} else {
+				res.Fields = append(res.Fields, BindFieldWallClockSample{Field: &typ.Fields[i]}) // skip changed field
+			}
+		case "contextId":
+			if typ.Fields[i].Equals(&def.Field{Name: "contextId", Type: typeMap.T_LONG, ConstantPool: false, Array: false}) {
+				res.Fields = append(res.Fields, BindFieldWallClockSample{Field: &typ.Fields[i], uint64: &res.Temp.ContextId})
+			} else {
+				res.Fields = append(res.Fields, BindFieldWallClockSample{Field: &typ.Fields[i]}) // skip changed field
+			}
 		case "samples":
 			if typ.Fields[i].Equals(&def.Field{Name: "samples", Type: typeMap.T_INT, ConstantPool: false, Array: false}) {
 				res.Fields = append(res.Fields, BindFieldWallClockSample{Field: &typ.Fields[i], uint32: &res.Temp.Samples})
@@ -70,6 +88,9 @@ type WallClockSample struct {
 	SampledThread ThreadRef
 	StackTrace    StackTraceRef
 	State         ThreadStateRef
+	SpanId        uint64
+	SpanName      uint64
+	ContextId     uint64
 	Samples       uint32
 }
 

--- a/pprof/parser.go
+++ b/pprof/parser.go
@@ -80,7 +80,12 @@ func parse(parser *parser.Parser, piOriginal *ParseInput, jfrLabels *LabelsSnaps
 			}
 		case parser.TypeMap.T_WALL_CLOCK_SAMPLE:
 			values[0] = int64(parser.WallClockSample.Samples)
-			builders.addStacktrace(sampleTypeWall, StacktraceCorrelation{}, parser.WallClockSample.StackTrace, values[:1])
+			correlation := StacktraceCorrelation{
+				ContextId: parser.WallClockSample.ContextId,
+				SpanId:    parser.WallClockSample.SpanId,
+				SpanName:  parser.WallClockSample.SpanName,
+			}
+			builders.addStacktrace(sampleTypeWall, correlation, parser.WallClockSample.StackTrace, values[:1])
 		case parser.TypeMap.T_ALLOC_IN_NEW_TLAB:
 			values[1] = int64(parser.ObjectAllocationInNewTLAB.TlabSize)
 			correlation := StacktraceCorrelation{


### PR DESCRIPTION
## Summary

This PR adds span correlation support (`spanId`, `spanName`, `contextId`) for `WallClockSample` JFR events, enabling span-based queries for wall-clock profiles in Pyroscope.

Resolves https://github.com/grafana/jfr-parser/issues/81

## Changes

### `parser/types/wall_clock_sample.go`
- Added `SpanId`, `SpanName`, `ContextId` fields to `WallClockSample` struct
- Added field bindings in `NewBindWallClockSample` for `spanId`, `spanName`, `contextId`

### `pprof/parser.go`
- Updated `T_WALL_CLOCK_SAMPLE` case to populate `StacktraceCorrelation` with span data from the event (previously passed empty struct)

## Motivation

Wall-clock profiling is essential for understanding application behavior including I/O wait, sleep, and blocked time. With the addition of span data to wall profiling in async-profiler (https://github.com/grafana/async-profiler/pull/11), users can now correlate wall profiles with distributed traces.

However, jfr-parser was not extracting this span metadata from `WallClockSample` events, causing span-based queries to fail for wall profiles while working correctly for CPU profiles (`ExecutionSample`).

## Testing

- [x] Verified wall profiles with span data are correctly parsed
- [x] Confirmed span-based queries return expected results in Pyroscope
- [x] Existing CPU profile span correlation continues to work

## Example

Before this change:
```
# Query wall profile by span_id - returns empty
curl "http://localhost:4040/pyroscope/render?query=wall:wall:nanoseconds:wall:nanoseconds{service_name=\"my-service\"}&span_selector=abc123"
# Returns: empty profile
```

After this change:
```
# Query wall profile by span_id - returns profile data
curl "http://localhost:4040/pyroscope/render?query=wall:wall:nanoseconds:wall:nanoseconds{service_name=\"my-service\"}&span_selector=abc123"  
# Returns: wall profile filtered to span abc123
```

## Related

- Resolves: https://github.com/grafana/jfr-parser/issues/81
- Related async-profiler issue: https://github.com/grafana/async-profiler/issues/10
- Async-profiler PR: https://github.com/grafana/async-profiler/pull/11