### PR TITLE
fix: avoid app_name duplicates

### DIFF
--- a/pprof/pyroscope/pyroscope.go
+++ b/pprof/pyroscope/pyroscope.go
@@ -66,10 +66,20 @@ func Labels(seriesLabels map[string]string, jfrEvent, metricName, appName, spyNa
 		},
 	)
 	if appName != "" {
-		ls = append(ls, &v1.LabelPair{
-			Name:  serviceNameLabelName,
-			Value: appName,
-		})
+		alreadySet := false
+		for _, label := range ls {
+			if label.Name == serviceNameLabelName {
+
+				alreadySet = true
+				break
+			}
+		}
+		if !alreadySet {
+			ls = append(ls, &v1.LabelPair{
+				Name:  serviceNameLabelName,
+				Value: appName,
+			})
+		}
 	}
 	return ls
 }

--- a/pprof/pyroscope/pyroscope_test.go
+++ b/pprof/pyroscope/pyroscope_test.go
@@ -1,0 +1,72 @@
+package pyroscope
+
+import (
+	"testing"
+
+	v1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+func labelMap(ls []*v1.LabelPair) map[string][]string {
+	m := make(map[string][]string)
+	for _, l := range ls {
+		m[l.Name] = append(m[l.Name], l.Value)
+	}
+	return m
+}
+
+// Fixed labels are always present regardless of inputs.
+func TestLabels_FixedLabelsAlwaysPresent(t *testing.T) {
+	m := labelMap(Labels(nil, "cpu", "process_cpu", "myapp", "jfr"))
+
+	assert.Equal(t, []string{"jfr"}, m[LabelNamePyroscopeSpy])
+	assert.Equal(t, []string{"false"}, m[LabelNameDelta])
+	assert.Equal(t, []string{"cpu"}, m[LabelNameJfrEvent])
+	assert.Equal(t, []string{"process_cpu"}, m[LabelNameProfileName])
+}
+
+// No service_name in seriesLabels: appName is added as service_name.
+func TestLabels_AppNameAddedAsServiceName(t *testing.T) {
+	m := labelMap(Labels(map[string]string{"env": "prod"}, "cpu", "process_cpu", "myapp", "jfr"))
+
+	assert.Equal(t, []string{"myapp"}, m[LabelNameServiceName])
+	assert.Nil(t, m["app_name"])
+}
+
+// service_name already in seriesLabels: appName is added as app_name.
+func TestLabels_AppNameFallsBackToAppName(t *testing.T) {
+	m := labelMap(Labels(map[string]string{LabelNameServiceName: "existing"}, "cpu", "process_cpu", "myapp", "jfr"))
+
+	assert.Equal(t, []string{"existing"}, m[LabelNameServiceName])
+	assert.Equal(t, []string{"myapp"}, m["app_name"])
+}
+
+// Both service_name and app_name in seriesLabels: app_name must not be duplicated.
+func TestLabels_NoDuplicateAppName(t *testing.T) {
+	m := labelMap(Labels(
+		map[string]string{LabelNameServiceName: "svc", "app_name": "original"},
+		"cpu", "process_cpu", "myapp", "jfr",
+	))
+
+	assert.Equal(t, []string{"original"}, m["app_name"])
+}
+
+// appName is empty: neither service_name nor app_name is appended.
+func TestLabels_EmptyAppNameNotAppended(t *testing.T) {
+	m := labelMap(Labels(map[string]string{"env": "prod"}, "cpu", "process_cpu", "", "jfr"))
+
+	assert.Nil(t, m[LabelNameServiceName])
+	assert.Nil(t, m["app_name"])
+}
+
+// Private labels (starting with __) are filtered out, except __session_id__.
+func TestLabels_PrivateLabelsFiltered(t *testing.T) {
+	m := labelMap(Labels(
+		map[string]string{"__private__": "secret", LabelNameSessionID: "sess123", "env": "prod"},
+		"cpu", "process_cpu", "myapp", "jfr",
+	))
+
+	assert.Nil(t, m["__private__"])
+	assert.Equal(t, []string{"sess123"}, m[LabelNameSessionID])
+	assert.Equal(t, []string{"prod"}, m["env"])
+}


### PR DESCRIPTION
This PR tries to fix the corner case bug described below.

# Bug description
When chaining two or more alloy instances, this logic [here](https://github.com/grafana/alloy/blob/main/internal/component/pyroscope/receive_http/receive_http.go#L322-L326) enhances the profiles with both `service_name` and `app_name`. 

In that situation, when the profile reaches pyroscope, it gets a second value of `app_name` appended. Then ingestion fails due to duplicate label.

# Proposed solution
I propose to only add `app_name` if it's not already present. 

## Solution analysis
This solution works for most of the cases and is the simplest imo. There's only one corner case not covered by this approach, when a user is legitimately sending profiles with different values of `__name__`, `service_name` and `app_name`. In that case, `__name__` would be silently missed.

## Other alternatives
* We could also remove the `app_name` logic in alloy, so it never gets added there in the first place, and leave that logic to the pyroscope backend, although I'm not sure if that logic is from an otel requirement, which I'm not very familiar with.
* We could remove the duplicate here if label values match, and return an error if a conflict exists. I was avoiding this because we would be changing the library api and this becomes a breaking change.