### PR TITLE
feat: add jfrwriter package for generating JFR files in tests

### DIFF
--- a/jfrwriter/builder.go
+++ b/jfrwriter/builder.go
@@ -1,0 +1,321 @@
+package jfrwriter
+
+import (
+	"encoding/binary"
+	"fmt"
+	"sort"
+	"strconv"
+
+	"github.com/grafana/jfr-parser/parser/types/def"
+)
+
+const chunkHeaderSize = 68
+const chunkMagic = 0x464c5200
+const chunkVersion = 0x00020000
+
+type cpoolEntry struct {
+	id   uint64
+	data []byte
+}
+
+type rawEvent struct {
+	typeID def.TypeID
+	data   []byte
+}
+
+// Builder accumulates metadata classes, constant pool entries, and events,
+// then serializes them into a valid JFR chunk.
+type Builder struct {
+	classes    []def.Class
+	classIndex map[string]int // name -> index into classes
+
+	cpoolEntries map[def.TypeID][]cpoolEntry
+	events       []rawEvent
+
+	startNanos     uint64
+	durationNanos  uint64
+	startTicks     uint64
+	ticksPerSecond uint64
+	features       uint32
+}
+
+// NewBuilder creates a new Builder with sensible defaults.
+func NewBuilder() *Builder {
+	return &Builder{
+		classIndex:     make(map[string]int),
+		cpoolEntries:   make(map[def.TypeID][]cpoolEntry),
+		startNanos:     1000000000,
+		durationNanos:  10000000,
+		startTicks:     100,
+		ticksPerSecond: 1000000000,
+	}
+}
+
+// SetTiming configures the chunk timing fields.
+func (b *Builder) SetTiming(startNanos, durationNanos, startTicks, ticksPerSecond uint64) *Builder {
+	b.startNanos = startNanos
+	b.durationNanos = durationNanos
+	b.startTicks = startTicks
+	b.ticksPerSecond = ticksPerSecond
+	return b
+}
+
+// AddClasses registers class definitions for the metadata section.
+// Duplicate names are replaced.
+func (b *Builder) AddClasses(classes ...def.Class) *Builder {
+	for _, c := range classes {
+		if idx, ok := b.classIndex[c.Name]; ok {
+			b.classes[idx] = c
+		} else {
+			b.classIndex[c.Name] = len(b.classes)
+			b.classes = append(b.classes, c)
+		}
+	}
+	return b
+}
+
+// AddCPoolEntry adds a constant pool entry for the given typeID.
+// data contains the pre-serialized field values for the entry.
+// id is the constant pool reference ID for this entry.
+func (b *Builder) AddCPoolEntry(typeID def.TypeID, id uint64, data []byte) *Builder {
+	b.cpoolEntries[typeID] = append(b.cpoolEntries[typeID], cpoolEntry{id: id, data: data})
+	return b
+}
+
+// AddEvent adds an event with the given typeID.
+// data contains the pre-serialized field values (size and typeID prefix are added by Build).
+func (b *Builder) AddEvent(typeID def.TypeID, data []byte) *Builder {
+	b.events = append(b.events, rawEvent{typeID: typeID, data: data})
+	return b
+}
+
+// Build serializes the chunk into a complete JFR byte slice.
+func (b *Builder) Build() ([]byte, error) {
+	eventsData := b.buildEvents()
+	cpoolData := b.buildConstantPool()
+	metaData, err := b.buildMetadata()
+	if err != nil {
+		return nil, fmt.Errorf("building metadata: %w", err)
+	}
+
+	totalSize := chunkHeaderSize + len(eventsData) + len(cpoolData) + len(metaData)
+	offsetCPool := chunkHeaderSize + len(eventsData)
+	offsetMeta := chunkHeaderSize + len(eventsData) + len(cpoolData)
+
+	buf := make([]byte, totalSize)
+	// Chunk header (big-endian)
+	binary.BigEndian.PutUint32(buf[0:], chunkMagic)
+	binary.BigEndian.PutUint32(buf[4:], chunkVersion)
+	binary.BigEndian.PutUint64(buf[8:], uint64(totalSize))
+	binary.BigEndian.PutUint64(buf[16:], uint64(offsetCPool))
+	binary.BigEndian.PutUint64(buf[24:], uint64(offsetMeta))
+	binary.BigEndian.PutUint64(buf[32:], b.startNanos)
+	binary.BigEndian.PutUint64(buf[40:], b.durationNanos)
+	binary.BigEndian.PutUint64(buf[48:], b.startTicks)
+	binary.BigEndian.PutUint64(buf[56:], b.ticksPerSecond)
+	binary.BigEndian.PutUint32(buf[64:], b.features)
+
+	copy(buf[chunkHeaderSize:], eventsData)
+	copy(buf[offsetCPool:], cpoolData)
+	copy(buf[offsetMeta:], metaData)
+
+	return buf, nil
+}
+
+// buildEvents serializes all events.
+// Each event: [size:varLong][typeID:varLong][data]
+// size includes itself (from the parser: pp = pos before size, then pos = pp + size).
+func (b *Builder) buildEvents() []byte {
+	var w Writer
+	for _, e := range b.events {
+		innerLen := VarLongSize(uint64(e.typeID)) + len(e.data)
+		totalSize := computeEventSize(innerLen)
+		w.VarLong(uint64(totalSize))
+		w.VarLong(uint64(e.typeID))
+		w.Raw(e.data)
+	}
+	return w.Bytes()
+}
+
+// computeEventSize finds the total event size (including the size field itself).
+// size = varLongSize(size) + innerLen, which is self-referential.
+func computeEventSize(innerLen int) int {
+	for candidateSize := innerLen + 1; candidateSize <= innerLen+10; candidateSize++ {
+		if VarLongSize(uint64(candidateSize))+innerLen == candidateSize {
+			return candidateSize
+		}
+	}
+	return innerLen + 1
+}
+
+// buildConstantPool serializes the constant pool section.
+func (b *Builder) buildConstantPool() []byte {
+	// Serialize the content (everything after the size field).
+	var content Writer
+	content.VarLong(1) // type = T_CPOOL
+	content.VarLong(0) // startTimeTicks
+	content.VarLong(0) // duration
+	content.VarLong(0) // delta = 0 (no chaining)
+	content.VarInt(1)  // flush = true
+
+	// Sort type IDs for deterministic output.
+	typeIDs := make([]def.TypeID, 0, len(b.cpoolEntries))
+	for tid := range b.cpoolEntries {
+		typeIDs = append(typeIDs, tid)
+	}
+	sort.Slice(typeIDs, func(i, j int) bool { return typeIDs[i] < typeIDs[j] })
+
+	content.VarInt(uint32(len(typeIDs)))
+	for _, tid := range typeIDs {
+		entries := b.cpoolEntries[tid]
+		content.VarLong(uint64(tid))
+		content.VarInt(uint32(len(entries)))
+		for _, e := range entries {
+			content.VarLong(e.id)
+			content.Raw(e.data)
+		}
+	}
+
+	// Wrap with size prefix. Size includes itself.
+	contentBytes := content.Bytes()
+	totalSize := computeEventSize(len(contentBytes))
+
+	var w Writer
+	w.VarLong(uint64(totalSize))
+	w.Raw(contentBytes)
+	return w.Bytes()
+}
+
+// metaElement represents a node in the metadata element tree.
+type metaElement struct {
+	name     string
+	attrs    [][2]string
+	children []metaElement
+}
+
+// buildMetadata serializes the metadata section.
+func (b *Builder) buildMetadata() ([]byte, error) {
+	// Build element tree
+	tree := b.buildMetadataTree()
+
+	// Collect all strings into a string table
+	st := newStringTable()
+	collectStrings(&tree, st)
+
+	// Serialize string table
+	var strBuf Writer
+	for _, s := range st.strings() {
+		strBuf.String(s)
+	}
+
+	// Serialize element tree
+	var treeBuf Writer
+	serializeElement(&treeBuf, &tree, st)
+
+	// Assemble metadata section as an event-like structure:
+	// [size:varLong][type=0:varLong][0:varLong][0:varLong][0:varLong]
+	// [nStrings:varInt][strings...][element tree...]
+	// size is self-inclusive (same as events and cpool).
+	var content Writer
+	content.VarLong(0) // type = T_METADATA (0)
+	content.VarLong(0) // startTicks
+	content.VarLong(0) // duration
+	content.VarLong(0) // delta
+	content.VarInt(uint32(len(st.strings())))
+	content.Raw(strBuf.Bytes())
+	content.Raw(treeBuf.Bytes())
+
+	contentBytes := content.Bytes()
+	totalSize := computeEventSize(len(contentBytes))
+
+	var w Writer
+	w.VarLong(uint64(totalSize))
+	w.Raw(contentBytes)
+	return w.Bytes(), nil
+}
+
+func (b *Builder) buildMetadataTree() metaElement {
+	var classElements []metaElement
+	for i := range b.classes {
+		c := &b.classes[i]
+		var fieldElements []metaElement
+		for j := range c.Fields {
+			f := &c.Fields[j]
+			fieldAttrs := [][2]string{
+				{"name", f.Name},
+				{"class", strconv.FormatInt(int64(f.Type), 10)},
+			}
+			if f.ConstantPool {
+				fieldAttrs = append(fieldAttrs, [2]string{"constantPool", "true"})
+			}
+			if f.Array {
+				fieldAttrs = append(fieldAttrs, [2]string{"dimension", "1"})
+			}
+			fieldElements = append(fieldElements, metaElement{name: "field", attrs: fieldAttrs})
+		}
+		classAttrs := [][2]string{
+			{"id", strconv.FormatInt(int64(c.ID), 10)},
+			{"name", c.Name},
+		}
+		classElements = append(classElements, metaElement{name: "class", attrs: classAttrs, children: fieldElements})
+	}
+
+	return metaElement{
+		name: "root",
+		children: []metaElement{
+			{name: "metadata", children: classElements},
+			{name: "region"},
+		},
+	}
+}
+
+func collectStrings(e *metaElement, st *stringTable) {
+	st.add(e.name)
+	for _, attr := range e.attrs {
+		st.add(attr[0])
+		st.add(attr[1])
+	}
+	for i := range e.children {
+		collectStrings(&e.children[i], st)
+	}
+}
+
+func serializeElement(w *Writer, e *metaElement, st *stringTable) {
+	w.VarInt(uint32(st.index(e.name)))
+	w.VarInt(uint32(len(e.attrs)))
+	for _, attr := range e.attrs {
+		w.VarInt(uint32(st.index(attr[0])))
+		w.VarInt(uint32(st.index(attr[1])))
+	}
+	w.VarInt(uint32(len(e.children)))
+	for i := range e.children {
+		serializeElement(w, &e.children[i], st)
+	}
+}
+
+// stringTable maintains an ordered set of unique strings with index lookup.
+type stringTable struct {
+	strs    []string
+	indices map[string]int
+}
+
+func newStringTable() *stringTable {
+	return &stringTable{
+		indices: make(map[string]int),
+	}
+}
+
+func (st *stringTable) add(s string) {
+	if _, ok := st.indices[s]; !ok {
+		st.indices[s] = len(st.strs)
+		st.strs = append(st.strs, s)
+	}
+}
+
+func (st *stringTable) index(s string) int {
+	return st.indices[s]
+}
+
+func (st *stringTable) strings() []string {
+	return st.strs
+}

--- a/jfrwriter/builder_test.go
+++ b/jfrwriter/builder_test.go
@@ -1,0 +1,139 @@
+package jfrwriter_test
+
+import (
+	"io"
+	"testing"
+
+	"github.com/grafana/jfr-parser/jfrwriter"
+	"github.com/grafana/jfr-parser/parser"
+	"github.com/grafana/jfr-parser/parser/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// addMinimalCPool adds the minimal set of constant pool entries required
+// for the parser to process events with stack traces and threads.
+func addMinimalCPool(b *jfrwriter.Builder) {
+	// Symbols
+	b.AddCPoolEntry(jfrwriter.T_SYMBOL, 1, jfrwriter.SerializeSymbol("main"))
+	b.AddCPoolEntry(jfrwriter.T_SYMBOL, 2, jfrwriter.SerializeSymbol("()V"))
+	b.AddCPoolEntry(jfrwriter.T_SYMBOL, 3, jfrwriter.SerializeSymbol("com/example"))
+	b.AddCPoolEntry(jfrwriter.T_SYMBOL, 4, jfrwriter.SerializeSymbol("MyClass"))
+
+	// Frame type and thread state
+	b.AddCPoolEntry(jfrwriter.T_FRAME_TYPE, 1, jfrwriter.SerializeFrameType("Interpreted"))
+	b.AddCPoolEntry(jfrwriter.T_THREAD_STATE, 1, jfrwriter.SerializeThreadState("STATE_RUNNABLE"))
+
+	// Log level (required by async-profiler metadata)
+	b.AddCPoolEntry(jfrwriter.T_LOG_LEVEL, 1, jfrwriter.SerializeLogLevel("INFO"))
+
+	// Class loader, package, class
+	b.AddCPoolEntry(jfrwriter.T_CLASS_LOADER, 1, jfrwriter.SerializeClassLoader(0, 0))
+	b.AddCPoolEntry(jfrwriter.T_PACKAGE, 1, jfrwriter.SerializePackage(3))
+	b.AddCPoolEntry(jfrwriter.T_CLASS, 1, jfrwriter.SerializeClass(1, 4, 1, 0))
+
+	// Method
+	b.AddCPoolEntry(jfrwriter.T_METHOD, 1, jfrwriter.SerializeMethod(1, 1, 2, 0, false))
+
+	// Thread
+	b.AddCPoolEntry(jfrwriter.T_THREAD, 1, jfrwriter.SerializeThread("main", 1, "main-thread", 1))
+
+	// Stack trace with one frame
+	b.AddCPoolEntry(jfrwriter.T_STACK_TRACE, 1, jfrwriter.SerializeStackTrace(false, [][]byte{
+		jfrwriter.SerializeStackFrame(1, 42, 0, 1),
+	}))
+}
+
+func TestRoundTripExecutionSample(t *testing.T) {
+	b := jfrwriter.NewBuilder()
+	b.AddClasses(jfrwriter.AllClasses()...)
+	addMinimalCPool(b)
+
+	b.AddEvent(jfrwriter.T_EXECUTION_SAMPLE,
+		jfrwriter.SerializeExecutionSample(500, 1, 1, 1))
+
+	data, err := b.Build()
+	require.NoError(t, err)
+
+	p := parser.NewParser(data, parser.Options{})
+	typ, err := p.ParseEvent()
+	require.NoError(t, err)
+	assert.Equal(t, p.TypeMap.T_EXECUTION_SAMPLE, typ)
+	assert.Equal(t, types.ThreadRef(1), p.ExecutionSample.SampledThread)
+	assert.Equal(t, types.StackTraceRef(1), p.ExecutionSample.StackTrace)
+	assert.Equal(t, types.ThreadStateRef(1), p.ExecutionSample.State)
+
+	_, err = p.ParseEvent()
+	assert.Equal(t, io.EOF, err)
+}
+
+// TestRoundTripObjectAllocationSample exercises the T_ALLOC_SAMPLE code path
+// in parser.go:199-208. This is the regression test for issue #89:
+// https://github.com/grafana/jfr-parser/issues/89
+//
+// The bug is a missing "continue" after the skip in the T_ALLOC_SAMPLE case.
+// This test generates a valid JFR with ObjectAllocationSample events and verifies
+// the parser handles them correctly.
+func TestRoundTripObjectAllocationSample(t *testing.T) {
+	b := jfrwriter.NewBuilder()
+	b.AddClasses(jfrwriter.AllClasses()...)
+	addMinimalCPool(b)
+
+	b.AddEvent(jfrwriter.T_ALLOC_SAMPLE,
+		jfrwriter.SerializeObjectAllocationSample(500, 1, 1, 1, 1024))
+
+	data, err := b.Build()
+	require.NoError(t, err)
+
+	p := parser.NewParser(data, parser.Options{})
+	typ, err := p.ParseEvent()
+	require.NoError(t, err)
+	assert.Equal(t, p.TypeMap.T_ALLOC_SAMPLE, typ)
+	assert.Equal(t, uint64(1024), p.ObjectAllocationSample.Weight)
+	assert.Equal(t, types.ThreadRef(1), p.ObjectAllocationSample.EventThread)
+	assert.Equal(t, types.StackTraceRef(1), p.ObjectAllocationSample.StackTrace)
+	assert.Equal(t, types.ClassRef(1), p.ObjectAllocationSample.ObjectClass)
+
+	_, err = p.ParseEvent()
+	assert.Equal(t, io.EOF, err)
+}
+
+func TestRoundTripMultipleEvents(t *testing.T) {
+	b := jfrwriter.NewBuilder()
+	b.AddClasses(jfrwriter.AllClasses()...)
+	addMinimalCPool(b)
+
+	// Add two execution samples and one alloc sample
+	b.AddEvent(jfrwriter.T_EXECUTION_SAMPLE,
+		jfrwriter.SerializeExecutionSample(100, 1, 1, 1))
+	b.AddEvent(jfrwriter.T_ALLOC_SAMPLE,
+		jfrwriter.SerializeObjectAllocationSample(200, 1, 1, 1, 2048))
+	b.AddEvent(jfrwriter.T_EXECUTION_SAMPLE,
+		jfrwriter.SerializeExecutionSample(300, 1, 1, 1))
+
+	data, err := b.Build()
+	require.NoError(t, err)
+
+	p := parser.NewParser(data, parser.Options{})
+
+	// First event: execution sample
+	typ, err := p.ParseEvent()
+	require.NoError(t, err)
+	assert.Equal(t, p.TypeMap.T_EXECUTION_SAMPLE, typ)
+	assert.Equal(t, uint64(100), p.ExecutionSample.StartTime)
+
+	// Second event: alloc sample
+	typ, err = p.ParseEvent()
+	require.NoError(t, err)
+	assert.Equal(t, p.TypeMap.T_ALLOC_SAMPLE, typ)
+	assert.Equal(t, uint64(2048), p.ObjectAllocationSample.Weight)
+
+	// Third event: execution sample
+	typ, err = p.ParseEvent()
+	require.NoError(t, err)
+	assert.Equal(t, p.TypeMap.T_EXECUTION_SAMPLE, typ)
+	assert.Equal(t, uint64(300), p.ExecutionSample.StartTime)
+
+	_, err = p.ParseEvent()
+	assert.Equal(t, io.EOF, err)
+}

--- a/jfrwriter/classes.go
+++ b/jfrwriter/classes.go
@@ -1,0 +1,246 @@
+package jfrwriter
+
+import "github.com/grafana/jfr-parser/parser/types/def"
+
+// Predefined type IDs matching async-profiler conventions.
+// These mirror the definitions in internal/cmd/gen/types.go.
+var (
+	T_METADATA                = def.TypeID(0)
+	T_CPOOL                   = def.TypeID(1)
+	T_BOOLEAN                 = def.TypeID(4)
+	T_CHAR                    = def.TypeID(5)
+	T_FLOAT                   = def.TypeID(6)
+	T_DOUBLE                  = def.TypeID(7)
+	T_BYTE                    = def.TypeID(8)
+	T_SHORT                   = def.TypeID(9)
+	T_INT                     = def.TypeID(10)
+	T_LONG                    = def.TypeID(11)
+	T_STRING                  = def.TypeID(20)
+	T_CLASS                   = def.TypeID(21)
+	T_THREAD                  = def.TypeID(22)
+	T_CLASS_LOADER            = def.TypeID(23)
+	T_FRAME_TYPE              = def.TypeID(24)
+	T_THREAD_STATE            = def.TypeID(25)
+	T_STACK_TRACE             = def.TypeID(26)
+	T_STACK_FRAME             = def.TypeID(27)
+	T_METHOD                  = def.TypeID(28)
+	T_PACKAGE                 = def.TypeID(29)
+	T_SYMBOL                  = def.TypeID(30)
+	T_LOG_LEVEL               = def.TypeID(31)
+	T_EVENT                   = def.TypeID(100)
+	T_EXECUTION_SAMPLE        = def.TypeID(101)
+	T_ALLOC_IN_NEW_TLAB       = def.TypeID(102)
+	T_ALLOC_OUTSIDE_TLAB      = def.TypeID(103)
+	T_MONITOR_ENTER           = def.TypeID(104)
+	T_THREAD_PARK             = def.TypeID(105)
+	T_CPU_LOAD                = def.TypeID(106)
+	T_ACTIVE_RECORDING        = def.TypeID(107)
+	T_ACTIVE_SETTING          = def.TypeID(108)
+	T_OS_INFORMATION          = def.TypeID(109)
+	T_CPU_INFORMATION         = def.TypeID(110)
+	T_JVM_INFORMATION         = def.TypeID(111)
+	T_INITIAL_SYSTEM_PROPERTY = def.TypeID(112)
+	T_NATIVE_LIBRARY          = def.TypeID(113)
+	T_LOG                     = def.TypeID(114)
+	T_LIVE_OBJECT             = def.TypeID(115)
+	T_WALL_CLOCK_SAMPLE       = def.TypeID(118)
+	T_MALLOC                  = def.TypeID(119)
+	T_FREE                    = def.TypeID(120)
+	T_ANNOTATION              = def.TypeID(200)
+	T_LABEL                   = def.TypeID(201)
+	T_CATEGORY                = def.TypeID(202)
+	T_TIMESTAMP               = def.TypeID(203)
+	T_TIMESPAN                = def.TypeID(204)
+	T_DATA_AMOUNT             = def.TypeID(205)
+	T_MEMORY_ADDRESS          = def.TypeID(206)
+	T_UNSIGNED                = def.TypeID(207)
+	T_PERCENTAGE              = def.TypeID(208)
+	T_ALLOC_SAMPLE            = def.TypeID(209)
+)
+
+// AllClasses returns all predefined class definitions used by async-profiler.
+func AllClasses() []def.Class {
+	return []def.Class{
+		// Primitives
+		{Name: "boolean", ID: T_BOOLEAN},
+		{Name: "char", ID: T_CHAR},
+		{Name: "float", ID: T_FLOAT},
+		{Name: "double", ID: T_DOUBLE},
+		{Name: "byte", ID: T_BYTE},
+		{Name: "short", ID: T_SHORT},
+		{Name: "int", ID: T_INT},
+		{Name: "long", ID: T_LONG},
+		{Name: "java.lang.String", ID: T_STRING},
+
+		// Constant pool types
+		{Name: "java.lang.Class", ID: T_CLASS, Fields: []def.Field{
+			{Name: "classLoader", Type: T_CLASS_LOADER, ConstantPool: true},
+			{Name: "name", Type: T_SYMBOL, ConstantPool: true},
+			{Name: "package", Type: T_PACKAGE, ConstantPool: true},
+			{Name: "modifiers", Type: T_INT},
+		}},
+		{Name: "java.lang.Thread", ID: T_THREAD, Fields: []def.Field{
+			{Name: "osName", Type: T_STRING},
+			{Name: "osThreadId", Type: T_LONG},
+			{Name: "javaName", Type: T_STRING},
+			{Name: "javaThreadId", Type: T_LONG},
+		}},
+		{Name: "jdk.types.ClassLoader", ID: T_CLASS_LOADER, Fields: []def.Field{
+			{Name: "type", Type: T_CLASS, ConstantPool: true},
+			{Name: "name", Type: T_SYMBOL, ConstantPool: true},
+		}},
+		{Name: "jdk.types.FrameType", ID: T_FRAME_TYPE, Fields: []def.Field{
+			{Name: "description", Type: T_STRING},
+		}},
+		{Name: "jdk.types.ThreadState", ID: T_THREAD_STATE, Fields: []def.Field{
+			{Name: "name", Type: T_STRING},
+		}},
+		{Name: "jdk.types.StackTrace", ID: T_STACK_TRACE, Fields: []def.Field{
+			{Name: "truncated", Type: T_BOOLEAN},
+			{Name: "frames", Type: T_STACK_FRAME, Array: true},
+		}},
+		{Name: "jdk.types.StackFrame", ID: T_STACK_FRAME, Fields: []def.Field{
+			{Name: "method", Type: T_METHOD, ConstantPool: true},
+			{Name: "lineNumber", Type: T_INT},
+			{Name: "bytecodeIndex", Type: T_INT},
+			{Name: "type", Type: T_FRAME_TYPE, ConstantPool: true},
+		}},
+		{Name: "jdk.types.Method", ID: T_METHOD, Fields: []def.Field{
+			{Name: "type", Type: T_CLASS, ConstantPool: true},
+			{Name: "name", Type: T_SYMBOL, ConstantPool: true},
+			{Name: "descriptor", Type: T_SYMBOL, ConstantPool: true},
+			{Name: "modifiers", Type: T_INT},
+			{Name: "hidden", Type: T_BOOLEAN},
+		}},
+		{Name: "jdk.types.Package", ID: T_PACKAGE, Fields: []def.Field{
+			{Name: "name", Type: T_SYMBOL, ConstantPool: true},
+		}},
+		{Name: "jdk.types.Symbol", ID: T_SYMBOL, Fields: []def.Field{
+			{Name: "string", Type: T_STRING},
+		}},
+		{Name: "profiler.types.LogLevel", ID: T_LOG_LEVEL, Fields: []def.Field{
+			{Name: "name", Type: T_STRING},
+		}},
+
+		// Event types
+		{Name: "jdk.ExecutionSample", ID: T_EXECUTION_SAMPLE, Fields: []def.Field{
+			{Name: "startTime", Type: T_LONG},
+			{Name: "sampledThread", Type: T_THREAD, ConstantPool: true},
+			{Name: "stackTrace", Type: T_STACK_TRACE, ConstantPool: true},
+			{Name: "state", Type: T_THREAD_STATE, ConstantPool: true},
+			{Name: "spanId", Type: T_LONG},
+			{Name: "spanName", Type: T_LONG},
+			{Name: "contextId", Type: T_LONG},
+		}},
+		{Name: "profiler.WallClockSample", ID: T_WALL_CLOCK_SAMPLE, Fields: []def.Field{
+			{Name: "startTime", Type: T_LONG},
+			{Name: "sampledThread", Type: T_THREAD, ConstantPool: true},
+			{Name: "stackTrace", Type: T_STACK_TRACE, ConstantPool: true},
+			{Name: "state", Type: T_THREAD_STATE, ConstantPool: true},
+			{Name: "spanId", Type: T_LONG},
+			{Name: "spanName", Type: T_LONG},
+			{Name: "contextId", Type: T_LONG},
+			{Name: "samples", Type: T_INT},
+		}},
+		{Name: "jdk.ObjectAllocationInNewTLAB", ID: T_ALLOC_IN_NEW_TLAB, Fields: []def.Field{
+			{Name: "startTime", Type: T_LONG},
+			{Name: "eventThread", Type: T_THREAD, ConstantPool: true},
+			{Name: "stackTrace", Type: T_STACK_TRACE, ConstantPool: true},
+			{Name: "objectClass", Type: T_CLASS, ConstantPool: true},
+			{Name: "allocationSize", Type: T_LONG},
+			{Name: "tlabSize", Type: T_LONG},
+			{Name: "contextId", Type: T_LONG},
+			{Name: "spanId", Type: T_LONG},
+			{Name: "spanName", Type: T_LONG},
+		}},
+		{Name: "jdk.ObjectAllocationOutsideTLAB", ID: T_ALLOC_OUTSIDE_TLAB, Fields: []def.Field{
+			{Name: "startTime", Type: T_LONG},
+			{Name: "eventThread", Type: T_THREAD, ConstantPool: true},
+			{Name: "stackTrace", Type: T_STACK_TRACE, ConstantPool: true},
+			{Name: "objectClass", Type: T_CLASS, ConstantPool: true},
+			{Name: "allocationSize", Type: T_LONG},
+			{Name: "contextId", Type: T_LONG},
+			{Name: "spanId", Type: T_LONG},
+			{Name: "spanName", Type: T_LONG},
+		}},
+		{Name: "jdk.ObjectAllocationSample", ID: T_ALLOC_SAMPLE, Fields: []def.Field{
+			{Name: "startTime", Type: T_LONG},
+			{Name: "eventThread", Type: T_THREAD, ConstantPool: true},
+			{Name: "stackTrace", Type: T_STACK_TRACE, ConstantPool: true},
+			{Name: "objectClass", Type: T_CLASS, ConstantPool: true},
+			{Name: "weight", Type: T_LONG},
+		}},
+		{Name: "jdk.JavaMonitorEnter", ID: T_MONITOR_ENTER, Fields: []def.Field{
+			{Name: "startTime", Type: T_LONG},
+			{Name: "duration", Type: T_LONG},
+			{Name: "eventThread", Type: T_THREAD, ConstantPool: true},
+			{Name: "stackTrace", Type: T_STACK_TRACE, ConstantPool: true},
+			{Name: "monitorClass", Type: T_CLASS, ConstantPool: true},
+			{Name: "previousOwner", Type: T_THREAD, ConstantPool: true},
+			{Name: "address", Type: T_LONG},
+			{Name: "contextId", Type: T_LONG},
+			{Name: "spanId", Type: T_LONG},
+			{Name: "spanName", Type: T_LONG},
+		}},
+		{Name: "jdk.ThreadPark", ID: T_THREAD_PARK, Fields: []def.Field{
+			{Name: "startTime", Type: T_LONG},
+			{Name: "duration", Type: T_LONG},
+			{Name: "eventThread", Type: T_THREAD, ConstantPool: true},
+			{Name: "stackTrace", Type: T_STACK_TRACE, ConstantPool: true},
+			{Name: "parkedClass", Type: T_CLASS, ConstantPool: true},
+			{Name: "timeout", Type: T_LONG},
+			{Name: "until", Type: T_LONG},
+			{Name: "address", Type: T_LONG},
+		}},
+		{Name: "profiler.LiveObject", ID: T_LIVE_OBJECT, Fields: []def.Field{
+			{Name: "startTime", Type: T_LONG},
+			{Name: "eventThread", Type: T_THREAD, ConstantPool: true},
+			{Name: "stackTrace", Type: T_STACK_TRACE, ConstantPool: true},
+			{Name: "objectClass", Type: T_CLASS, ConstantPool: true},
+			{Name: "allocationSize", Type: T_LONG},
+			{Name: "allocationTime", Type: T_LONG},
+		}},
+		{Name: "jdk.ActiveSetting", ID: T_ACTIVE_SETTING, Fields: []def.Field{
+			{Name: "startTime", Type: T_LONG},
+			{Name: "duration", Type: T_LONG},
+			{Name: "eventThread", Type: T_THREAD, ConstantPool: true},
+			{Name: "stackTrace", Type: T_STACK_TRACE, ConstantPool: true},
+			{Name: "id", Type: T_LONG},
+			{Name: "name", Type: T_STRING},
+			{Name: "value", Type: T_STRING},
+		}},
+		{Name: "profiler.Malloc", ID: T_MALLOC, Fields: []def.Field{
+			{Name: "startTime", Type: T_LONG},
+			{Name: "eventThread", Type: T_THREAD, ConstantPool: true},
+			{Name: "stackTrace", Type: T_STACK_TRACE, ConstantPool: true},
+			{Name: "address", Type: T_LONG},
+			{Name: "size", Type: T_LONG},
+		}},
+		{Name: "profiler.Free", ID: T_FREE, Fields: []def.Field{
+			{Name: "startTime", Type: T_LONG},
+			{Name: "eventThread", Type: T_THREAD, ConstantPool: true},
+			{Name: "stackTrace", Type: T_STACK_TRACE, ConstantPool: true},
+			{Name: "address", Type: T_LONG},
+		}},
+
+		// Annotation types
+		{Name: "jdk.jfr.Label", ID: T_LABEL, Fields: []def.Field{
+			{Name: "value", Type: T_STRING},
+		}},
+		{Name: "jdk.jfr.Category", ID: T_CATEGORY, Fields: []def.Field{
+			{Name: "value", Type: T_STRING, Array: true},
+		}},
+		{Name: "jdk.jfr.Timestamp", ID: T_TIMESTAMP, Fields: []def.Field{
+			{Name: "value", Type: T_STRING},
+		}},
+		{Name: "jdk.jfr.Timespan", ID: T_TIMESPAN, Fields: []def.Field{
+			{Name: "value", Type: T_STRING},
+		}},
+		{Name: "jdk.jfr.DataAmount", ID: T_DATA_AMOUNT, Fields: []def.Field{
+			{Name: "value", Type: T_STRING},
+		}},
+		{Name: "jdk.jfr.MemoryAddress", ID: T_MEMORY_ADDRESS},
+		{Name: "jdk.jfr.Unsigned", ID: T_UNSIGNED},
+		{Name: "jdk.jfr.Percentage", ID: T_PERCENTAGE},
+	}
+}

--- a/jfrwriter/encoding.go
+++ b/jfrwriter/encoding.go
@@ -1,0 +1,106 @@
+package jfrwriter
+
+import "bytes"
+
+// Writer wraps a bytes.Buffer with JFR-specific encoding methods.
+type Writer struct {
+	buf bytes.Buffer
+}
+
+// VarInt encodes v as a JFR variable-length 32-bit integer (LEB128 variant).
+func (w *Writer) VarInt(v uint32) {
+	for v >= 0x80 {
+		w.buf.WriteByte(byte(v&0x7F) | 0x80)
+		v >>= 7
+	}
+	w.buf.WriteByte(byte(v))
+}
+
+// VarLong encodes v as a JFR variable-length 64-bit integer.
+// Uses 7-bit groups with continuation bit. At shift==56, writes the full byte.
+func (w *Writer) VarLong(v uint64) {
+	for shift := uint(0); shift <= 56; shift += 7 {
+		if shift == 56 {
+			w.buf.WriteByte(byte(v >> 56))
+			return
+		}
+		if v < 0x80 {
+			w.buf.WriteByte(byte(v))
+			return
+		}
+		w.buf.WriteByte(byte(v&0x7F) | 0x80)
+		v >>= 7
+	}
+}
+
+// String encodes s as a JFR string.
+// Empty string -> type byte 1. Non-empty -> type byte 3 + varInt(len) + UTF-8 bytes.
+func (w *Writer) String(s string) {
+	if s == "" {
+		w.buf.WriteByte(1) // empty string
+		return
+	}
+	w.buf.WriteByte(3) // UTF-8
+	w.VarInt(uint32(len(s)))
+	w.buf.WriteString(s)
+}
+
+// Byte writes a single byte.
+func (w *Writer) Byte(b byte) {
+	w.buf.WriteByte(b)
+}
+
+// Bool writes a boolean as a single byte (0 or 1).
+func (w *Writer) Bool(b bool) {
+	if b {
+		w.buf.WriteByte(1)
+	} else {
+		w.buf.WriteByte(0)
+	}
+}
+
+// Raw writes raw bytes.
+func (w *Writer) Raw(data []byte) {
+	w.buf.Write(data)
+}
+
+// Bytes returns the accumulated bytes.
+func (w *Writer) Bytes() []byte {
+	return w.buf.Bytes()
+}
+
+// Len returns the current buffer length.
+func (w *Writer) Len() int {
+	return w.buf.Len()
+}
+
+// Reset clears the buffer.
+func (w *Writer) Reset() {
+	w.buf.Reset()
+}
+
+// VarIntSize returns the number of bytes needed to encode v as a varInt.
+func VarIntSize(v uint32) int {
+	n := 1
+	for v >= 0x80 {
+		n++
+		v >>= 7
+	}
+	return n
+}
+
+// VarLongSize returns the number of bytes needed to encode v as a varLong.
+func VarLongSize(v uint64) int {
+	n := 1
+	for shift := uint(0); shift <= 56; shift += 7 {
+		if shift == 56 {
+			return n
+		}
+		if v < 0x80 {
+			return n
+		}
+		n++
+		v >>= 7
+	}
+	return n
+}

--- a/jfrwriter/helpers.go
+++ b/jfrwriter/helpers.go
@@ -1,0 +1,132 @@
+package jfrwriter
+
+// SerializeSymbol serializes a Symbol constant pool entry: string field.
+func SerializeSymbol(s string) []byte {
+	var w Writer
+	w.String(s)
+	return w.Bytes()
+}
+
+// SerializeFrameType serializes a FrameType constant pool entry: description:string.
+func SerializeFrameType(description string) []byte {
+	var w Writer
+	w.String(description)
+	return w.Bytes()
+}
+
+// SerializeThreadState serializes a ThreadState constant pool entry: name:string.
+func SerializeThreadState(name string) []byte {
+	var w Writer
+	w.String(name)
+	return w.Bytes()
+}
+
+// SerializeThread serializes a Thread constant pool entry.
+// Fields: osName:string, osThreadId:long, javaName:string, javaThreadId:long.
+func SerializeThread(osName string, osThreadId uint64, javaName string, javaThreadId uint64) []byte {
+	var w Writer
+	w.String(osName)
+	w.VarLong(osThreadId)
+	w.String(javaName)
+	w.VarLong(javaThreadId)
+	return w.Bytes()
+}
+
+// SerializeClassLoader serializes a ClassLoader constant pool entry.
+// Fields: type:ClassRef(CP), name:SymbolRef(CP).
+func SerializeClassLoader(typeRef, nameRef uint64) []byte {
+	var w Writer
+	w.VarLong(typeRef)
+	w.VarLong(nameRef)
+	return w.Bytes()
+}
+
+// SerializeClass serializes a Class constant pool entry.
+// Fields: classLoader:ClassLoaderRef(CP), name:SymbolRef(CP), package:PackageRef(CP), modifiers:int.
+func SerializeClass(classLoaderRef, nameRef, packageRef uint64, modifiers uint32) []byte {
+	var w Writer
+	w.VarLong(classLoaderRef)
+	w.VarLong(nameRef)
+	w.VarLong(packageRef)
+	w.VarInt(modifiers)
+	return w.Bytes()
+}
+
+// SerializeMethod serializes a Method constant pool entry.
+// Fields: type:ClassRef(CP), name:SymbolRef(CP), descriptor:SymbolRef(CP), modifiers:int, hidden:boolean.
+func SerializeMethod(typeRef, nameRef, descriptorRef uint64, modifiers uint32, hidden bool) []byte {
+	var w Writer
+	w.VarLong(typeRef)
+	w.VarLong(nameRef)
+	w.VarLong(descriptorRef)
+	w.VarInt(modifiers)
+	w.Bool(hidden)
+	return w.Bytes()
+}
+
+// SerializePackage serializes a Package constant pool entry.
+// Fields: name:SymbolRef(CP).
+func SerializePackage(nameRef uint64) []byte {
+	var w Writer
+	w.VarLong(nameRef)
+	return w.Bytes()
+}
+
+// SerializeStackFrame serializes a single StackFrame (inline struct, not a cpool entry).
+// Fields: method:MethodRef(CP), lineNumber:int, bytecodeIndex:int, type:FrameTypeRef(CP).
+func SerializeStackFrame(methodRef uint64, lineNumber, bytecodeIndex uint32, frameTypeRef uint64) []byte {
+	var w Writer
+	w.VarLong(methodRef)
+	w.VarInt(lineNumber)
+	w.VarInt(bytecodeIndex)
+	w.VarLong(frameTypeRef)
+	return w.Bytes()
+}
+
+// SerializeStackTrace serializes a StackTrace constant pool entry.
+// Fields: truncated:boolean, frames:StackFrame[].
+// Each frame should be pre-serialized with SerializeStackFrame.
+func SerializeStackTrace(truncated bool, frames [][]byte) []byte {
+	var w Writer
+	w.Bool(truncated)
+	w.VarInt(uint32(len(frames)))
+	for _, f := range frames {
+		w.Raw(f)
+	}
+	return w.Bytes()
+}
+
+// SerializeLogLevel serializes a LogLevel constant pool entry: name:string.
+func SerializeLogLevel(name string) []byte {
+	var w Writer
+	w.String(name)
+	return w.Bytes()
+}
+
+// SerializeExecutionSample serializes an ExecutionSample event body.
+// Fields: startTime:long, sampledThread:ThreadRef(CP), stackTrace:StackTraceRef(CP),
+// state:ThreadStateRef(CP), spanId:long, spanName:long, contextId:long.
+func SerializeExecutionSample(startTime, threadRef, stackTraceRef, stateRef uint64) []byte {
+	var w Writer
+	w.VarLong(startTime)
+	w.VarLong(threadRef)
+	w.VarLong(stackTraceRef)
+	w.VarLong(stateRef)
+	w.VarLong(0) // spanId
+	w.VarLong(0) // spanName
+	w.VarLong(0) // contextId
+	return w.Bytes()
+}
+
+// SerializeObjectAllocationSample serializes an ObjectAllocationSample event body.
+// Fields: startTime:long, eventThread:ThreadRef(CP), stackTrace:StackTraceRef(CP),
+// objectClass:ClassRef(CP), weight:long.
+func SerializeObjectAllocationSample(startTime, threadRef, stackTraceRef, classRef, weight uint64) []byte {
+	var w Writer
+	w.VarLong(startTime)
+	w.VarLong(threadRef)
+	w.VarLong(stackTraceRef)
+	w.VarLong(classRef)
+	w.VarLong(weight)
+	return w.Bytes()
+}


### PR DESCRIPTION
## Summary

Add a new `jfrwriter` utility package that generates valid JFR (Java Flight Recorder) binary files programmatically. This enables writing focused regression tests for parser bugs by constructing JFR files with specific event combinations, without needing real profiler output.

## Motivation

Currently, reproducing parser bugs requires capturing real JFR files from async-profiler or the JVM. This is cumbersome and often impossible for edge cases. The writer package allows constructing minimal JFR files that exercise specific parser code paths — for example, the `jdk.ObjectAllocationSample` event handling path related to #89.

## What's included

### `jfrwriter/encoding.go`
Low-level encoding primitives (`Writer` struct) — the write counterparts to the parser's `varInt`/`varLong`/`string` decoders.

### `jfrwriter/classes.go`
All predefined async-profiler type ID constants and `AllClasses()` which returns the full set of `def.Class` definitions (primitives, constant pool types, event types, annotations). These mirror the definitions in `internal/cmd/gen/types.go` but are exported for use in tests.

### `jfrwriter/helpers.go`
Serialization helpers for common constant pool entries (`SerializeSymbol`, `SerializeThread`, `SerializeStackTrace`, etc.) and event bodies (`SerializeExecutionSample`, `SerializeObjectAllocationSample`).

### `jfrwriter/builder.go`
Fluent `Builder` API that assembles a complete JFR chunk:
```go
b := jfrwriter.NewBuilder()
b.AddClasses(jfrwriter.AllClasses()...)
b.AddCPoolEntry(jfrwriter.T_THREAD, 1, jfrwriter.SerializeThread("main", 1, "main", 1))
b.AddEvent(jfrwriter.T_EXECUTION_SAMPLE, jfrwriter.SerializeExecutionSample(500, 1, 1, 1))
data, err := b.Build()
```

The builder handles all binary format details: chunk header (big-endian), self-inclusive event sizes, constant pool section with type entries, and metadata section with string table and element tree.

### `jfrwriter/builder_test.go`
Round-trip tests that build JFR files and parse them back with the existing parser:
- **`TestRoundTripExecutionSample`** — basic round-trip with `jdk.ExecutionSample`
- **`TestRoundTripObjectAllocationSample`** — exercises the `T_ALLOC_SAMPLE` code path (regression test for #89)
- **`TestRoundTripMultipleEvents`** — mixed event types in a single chunk

## Design decisions

- **Pre-serialized `[]byte` for field data** — enables emitting events for types without a predefined Go struct, satisfying the "arbitrary events" requirement
- **Duplicated class definitions** (from `internal/cmd/gen/types.go`) — necessary because Go prevents importing `internal` packages from outside the module tree
- **Tree-based metadata serialization** — builds the element tree in memory first, then collects strings into a table and serializes, avoiding two-pass complexity

🤖 Generated with [Claude Code](https://claude.com/claude-code)