### PR TITLE
fix: prevent panic on JFR events with invalid size fields

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -122,6 +122,9 @@ func (p *Parser) ParseEvent() (def.TypeID, error) {
 		if size == 0 {
 			return 0, def.ErrIntOverflow
 		}
+		if uint64(p.chunkEnd-pp) < size {
+			return 0, fmt.Errorf("invalid event size %d at position %d", size, pp)
+		}
 		typ, err := p.varLong()
 		if err != nil {
 			return 0, err
@@ -330,7 +333,7 @@ func (p *Parser) readChunk(pos int) error {
 }
 
 func (p *Parser) seek(pos int) error {
-	if pos < len(p.buf) {
+	if pos >= 0 && pos < len(p.buf) {
 		p.pos = pos
 		return nil
 	}

--- a/pprof/parser_test.go
+++ b/pprof/parser_test.go
@@ -437,3 +437,32 @@ func stackCollapseProto(p *profilev1.Profile, lineNumbers bool) string {
 func TestProfileId(t *testing.T) {
 	assert.Equal(t, "00000000000000ef", profileIdString(0xef))
 }
+
+// TestParseJFROversizedEventSize is a regression test for
+// https://github.com/grafana/jfr-parser/issues/90.
+// An event whose size field encodes a uint64 with the high bit set causes
+// int(size) to be a large negative number, making p.pos = pp + int(size)
+// negative. The next p.buf[p.pos] access then panics with
+// "index out of range [negative]". The fix validates size against the chunk
+// bounds before advancing p.pos.
+func TestParseJFROversizedEventSize(t *testing.T) {
+	data := readGzipFile(t, testdataDir+"example.jfr.gz")
+
+	// Overwrite the first event's size varint (at offset 68, right after the
+	// chunk header) with 9 bytes of 0x80. The modified LEB128 decoder reads
+	// the 9th byte with all 8 bits, giving uint64(0x8000000000000000).
+	// int(0x8000000000000000) == math.MinInt64, so without the fix
+	// p.pos = 68 + MinInt64 which is deeply negative and causes a panic.
+	const chunkHeaderSize = 68
+	copy(data[chunkHeaderSize:], []byte{0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80})
+
+	pi := &ParseInput{
+		StartTime: time.Now(),
+		EndTime:   time.Now().Add(time.Minute),
+	}
+
+	require.NotPanics(t, func() {
+		_, err := ParseJFR(data, pi, nil, WithDisablePanicRecovery(true))
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
## Summary

Fixes #90

An event whose size varint encodes a `uint64` larger than the remaining chunk caused two related bugs:

**Bug 1 — negative index panic** (the primary crash)

Values with the MSB set (e.g. `0x8000000000000000`) become negative when cast to `int`, so `p.pos = pp + int(size)` goes deeply negative. The next `p.buf[p.pos]` access panics:
```
jfr parser panic: runtime error: index out of range [-9223372036853131180]
```

**Bug 2 — `seek()` accepts negative positions**

`seek()` only checked `pos < len(p.buf)`, which is always true for negative values, silently setting `p.pos` to a negative value.

## Changes

- `ParseEvent`: validate `size` against chunk bounds before advancing `p.pos`
- `seek()`: add `pos >= 0` guard
- Regression test: corrupts a real JFR's first event size to `0x8000000000000000` and asserts `NotPanics` + error returned

## Testing

Regression test added (`TestParseJFROversizedEventSize`). Also validated against 78 real-world crash files from the affected tenant — 0 panics, all return clean errors. 10 of those files encoded exactly `9223372036854775808` (`math.MinInt64`) as the event size and would have triggered the exact panic in the bug report.