### PR TITLE
perf: regex fast-path for mergeJVMGeneratedClasses (-62% allocs)

### DIFF
--- a/parser/symbols.go
+++ b/parser/symbols.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"regexp"
+	"strings"
 
 	"github.com/grafana/jfr-parser/parser/types"
 )
@@ -30,16 +31,28 @@ var cglibEnhancer = regexp.MustCompile("^(.+\\$\\$EnhancerBySpringCGLIB\\$\\$)(.
 // TODO
 // ./tmp/snappy-1.1.8-6fb9393a-3093-4706-a7e4-837efe01d078-libsnappyjava.so
 func mergeJVMGeneratedClasses(frame string) string {
-	frame = generatedMethodAccessor.ReplaceAllString(frame, "${1}_")
-	frame = lambdaGeneratedEnclosingClass.ReplaceAllString(frame, "${1}_")
-	frame = zstdJniSoLibName.ReplaceAllString(frame, "libzstd-jni-_.so")
-	frame = amazonCorrettoCryptoProvider.ReplaceAllString(frame, "libamazonCorrettoCryptoProvider_.so")
-	frame = pyroscopeAsyncProfiler.ReplaceAllString(frame, "libasyncProfiler-_.so")
-	frame = cglibEnhancer.ReplaceAllString(frame, "${1}_")
-	// todo(korniltsev): optimize this
-	// - [ ] replace inplace if underlying symbol if byte slice into the
-	// - [ ] less/no regexps
-
+	// Guard each regex with a cheap strings check so that ordinary class
+	// names (the vast majority) skip all regex work entirely.
+	// ReplaceAllString allocates even on no-match ([]byte(src) + string(b)),
+	// so avoiding the call is meaningful at scale.
+	if strings.HasPrefix(frame, "jdk/internal/reflect/GeneratedMethodAccessor") {
+		frame = generatedMethodAccessor.ReplaceAllString(frame, "${1}_")
+	}
+	if strings.Contains(frame, "$$Lambda") {
+		frame = lambdaGeneratedEnclosingClass.ReplaceAllString(frame, "${1}_")
+	}
+	if strings.Contains(frame, "libzstd-jni-") {
+		frame = zstdJniSoLibName.ReplaceAllString(frame, "libzstd-jni-_.so")
+	}
+	if strings.Contains(frame, "amazonCorrettoCryptoProvider") {
+		frame = amazonCorrettoCryptoProvider.ReplaceAllString(frame, "libamazonCorrettoCryptoProvider_.so")
+	}
+	if strings.Contains(frame, "libasyncProfiler-") {
+		frame = pyroscopeAsyncProfiler.ReplaceAllString(frame, "libasyncProfiler-_.so")
+	}
+	if strings.Contains(frame, "$$EnhancerBySpringCGLIB$$") {
+		frame = cglibEnhancer.ReplaceAllString(frame, "${1}_")
+	}
 	return frame
 }
 

--- a/pprof/parser_test.go
+++ b/pprof/parser_test.go
@@ -333,6 +333,47 @@ func BenchmarkParse(b *testing.B) {
 	}
 }
 
+// BenchmarkParseAlloc reproduces the allocation spike observed in the
+// Pyroscope distributor (distributor-alloc-spike.pprof). The hot paths are:
+//   - StackTraceList.Parse: make([]StackFrame, 0, n) per stack trace in each chunk
+//   - jfrPprofBuilders.addStacktrace: make([]uint64, 0, nLocs) + make([]int64, ...) per sample
+//   - ProfileBuilder.addLocation / addFunction / AddExternalSampleWithLabels: proto heap allocs
+//
+// Run with -memprofile=mem.pprof to capture an allocation profile for comparison.
+func BenchmarkParseAlloc(b *testing.B) {
+	r := heapReader()
+
+	cases := []testdata{
+		// Largest file: many stack traces → dominates StackTraceList.Parse allocs.
+		{jfr: "goland", expectedCount: 5},
+		// Multi-chunk variant: exercises chunk-boundary reset of IDMaps.
+		{jfr: "goland-multichunk", expectedCount: 5},
+		// CPU + lock + alloc: closest to the production event mix that triggered the spike.
+		{jfr: "cortex-dev-01__kafka-0__cpu_lock0_alloc0__0", expectedCount: 5},
+		// With labels snapshot: exercises AddExternalSampleWithLabels label allocs.
+		{jfr: "dump2", labels: "dump2.labels.pb.gz", expectedCount: 4},
+	}
+
+	for _, td := range cases {
+		b.Run(td.jfr, func(b *testing.B) {
+			jfr, _ := r(b, testdataDir+td.jfr+".jfr.gz")
+			ls, _ := readLabels(b, td, r)
+			b.SetBytes(int64(len(jfr)))
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				profiles, err := ParseJFR(jfr, parseInput, ls)
+				if err != nil {
+					b.Fatalf("ParseJFR: %s", err)
+				}
+				if len(profiles.Profiles) == 0 {
+					b.Fatalf("no profiles produced")
+				}
+			}
+		})
+	}
+}
+
 func toGoogleProfiles(t *testing.T, profiles []Profile) []gprofile {
 	res := make([]gprofile, 0, len(profiles))
 	for _, profile := range profiles {


### PR DESCRIPTION
## Summary

- `mergeJVMGeneratedClasses` calls `regexp.ReplaceAllString` six times per frame. `ReplaceAllString` allocates even on no-match (`[]byte(src)` + `string(b)`), so on production workloads where ~all class names match none of the patterns, this loop dominated the parser's allocation profile.
- Guard each regex with a cheap `strings.HasPrefix` / `strings.Contains` check so ordinary class names skip the regex entirely.
- Adds `BenchmarkParseAlloc` (four representative test files) to make this kind of change measurable from the repo.

## Evidence

`benchstat` (n=6, benchtime=2s, Apple M2 Max, `BenchmarkParseAlloc`):

| Case | allocs/op | B/op | sec/op |
|---|---|---|---|
| goland | **−56.4%** | −13.7% | −21.6% |
| goland-multichunk | **−84.3%** | −41.4% | −55.1% |
| cortex…cpu_lock0_alloc0__0 | **−67.2%** | −32.4% | −42.9% |
| dump2 | −11.7% | −2.2% | ~ (p=0.13) |
| **geomean** | **−62.5%** | **−24.0%** | **−33.2%** |

Top allocators (alloc_objects, goland, memprofilerate=1):
- Before: `regexp.replaceAll` + `ReplaceAllString` = **56.5%** of all allocs.
- After: regexp drops out of the top entries entirely.

Allocation flamegraphs (publicly shareable, pprof view):
- Diff: https://flamegraph.com/share/75d5a25e-4de3-11f1-94dd-963070b65142/75dde1e2-4de3-11f1-94dd-963070b65142
- Before: https://flamegraph.com/share/014f9ffe-4de3-11f1-94dd-963070b65142
- After: https://flamegraph.com/share/01cd5965-4de3-11f1-94dd-963070b65142

## Test plan

- [ ] `go test ./...` passes (existing symbol-rewriting tests cover the regex branches; the fast-path only skips work when the cheap substring check already proves a no-match).
- [ ] `benchstat` numbers reproduce locally (`go test -bench=BenchmarkParseAlloc -benchmem -count=6 ./pprof`).