### PR TITLE
chore: set toolchain to go1.25.10, language to go 1.25

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/grafana/jfr-parser
 
 go 1.25.0
 
+toolchain go1.25.10
+
 require (
 	github.com/google/pprof v0.0.0-20260507013755-92041b743c96
 	github.com/grafana/pyroscope/api v1.5.0


### PR DESCRIPTION
## Summary
- Add a `toolchain go1.25.10` directive to `go.mod`, pinning to the latest Go 1.25 patch release.
- Keep the language version at 1.25 (`go 1.25.0` is the canonical full-version form that go tooling normalizes to; bare `go 1.25` is rewritten to `go 1.25.0` by `go mod tidy`).

## Testing
- `go build ./...` (non-fuzz packages) passes
- `go test ./...` (non-fuzz packages) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)