### PR TITLE
feat: thread name options

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -281,6 +281,16 @@ func (p *Parser) GetThreadState(ref types2.ThreadStateRef) *types2.ThreadState {
 	return &p.ThreadStates.ThreadState[idx]
 }
 
+// GetThread resolves the thread a sample was taken on, or nil if the reference
+// is unknown. async-profiler populates this when started with the -t flag.
+func (p *Parser) GetThread(ref types2.ThreadRef) *types2.Thread {
+	idx, ok := p.Threads.IDMap[ref]
+	if !ok {
+		return nil
+	}
+	return &p.Threads.Thread[idx]
+}
+
 func (p *Parser) GetMethod(mID types2.MethodRef) *types2.Method {
 	idx, ok := p.Methods.IDMap[mID]
 	if !ok || int(idx) >= len(p.Methods.Method) {

--- a/pprof/parser.go
+++ b/pprof/parser.go
@@ -10,6 +10,9 @@ import (
 type pprofOptions struct {
 	truncatedFrame       bool
 	disablePanicRecovery bool
+	threadFrame          bool
+	threadLabelKey       string
+	threadLabelFn        func(threadName string) string
 }
 type Option func(*pprofOptions)
 
@@ -22,6 +25,29 @@ func WithTruncatedFrame(v bool) Option {
 func WithDisablePanicRecovery(v bool) Option {
 	return func(o *pprofOptions) {
 		o.disablePanicRecovery = v
+	}
+}
+
+// WithThreadFrame, when enabled, adds the sampled thread's name as a synthetic
+// root frame beneath each execution-sample stack, so flame graphs split by the
+// thread that ran the sample. Requires the profile to have been recorded with
+// per-thread sampling. Off by default.
+func WithThreadFrame(v bool) Option {
+	return func(o *pprofOptions) {
+		o.threadFrame = v
+	}
+}
+
+// WithThreadLabel adds a pprof sample label to each execution sample whose value
+// is derived from the sampled thread's name by fn. The caller supplies the
+// naming convention (e.g. extracting a thread-pool name via regexp), keeping
+// this package free of application-specific parsing. Requires per-thread
+// sampling. If fn returns "" for a sample, no label is added for it. A no-op
+// unless key is non-empty and fn is non-nil.
+func WithThreadLabel(key string, fn func(threadName string) string) Option {
+	return func(o *pprofOptions) {
+		o.threadLabelKey = key
+		o.threadLabelFn = fn
 	}
 }
 
@@ -72,6 +98,28 @@ func parse(parser *parser.Parser, piOriginal *ParseInput, jfrLabels *LabelsSnaps
 				SpanName:  parser.ExecutionSample.SpanName,
 				TraceIdHi: parser.ExecutionSample.TraceIdHi,
 				TraceIdLo: parser.ExecutionSample.TraceIdLo,
+			}
+			// When async-profiler runs with -t, each sample carries the thread it
+			// ran on. Managed JVM threads carry their full name in JavaName;
+			// native threads (GC, JIT compiler, VM tasks) have no JavaName and
+			// are identified only by OsName, so fall back to it. The name is used
+			// only when a thread frame or a thread label was requested.
+			if opt.threadFrame || (opt.threadLabelKey != "" && opt.threadLabelFn != nil) {
+				if t := parser.GetThread(parser.ExecutionSample.SampledThread); t != nil {
+					name := t.JavaName
+					if name == "" {
+						name = t.OsName
+					}
+					if opt.threadFrame {
+						correlation.ThreadName = name
+					}
+					if name != "" && opt.threadLabelFn != nil && opt.threadLabelKey != "" {
+						if v := opt.threadLabelFn(name); v != "" {
+							correlation.ThreadLabelKey = opt.threadLabelKey
+							correlation.ThreadLabelValue = v
+						}
+					}
+				}
 			}
 			if ts != nil && ts.Name != "STATE_SLEEPING" {
 				builders.addStacktrace(sampleTypeCPU, correlation, parser.ExecutionSample.StackTrace, values[:1])

--- a/pprof/parser.go
+++ b/pprof/parser.go
@@ -79,6 +79,24 @@ func parse(parser *parser.Parser, piOriginal *ParseInput, jfrLabels *LabelsSnaps
 
 	var values = [2]int64{1, 0}
 
+	// Transform is called per distinct thread name rather than per sample, since
+	// there are far fewer threads than samples and it may allocate.
+	var threadNameCache map[string]string
+	transformThreadName := func(name string) string {
+		if opt.thread.Transform == nil {
+			return name
+		}
+		if v, ok := threadNameCache[name]; ok {
+			return v
+		}
+		v := opt.thread.Transform(name)
+		if threadNameCache == nil {
+			threadNameCache = map[string]string{}
+		}
+		threadNameCache[name] = v
+		return v
+	}
+
 	for {
 		typ, err := parser.ParseEvent()
 		if err != nil {
@@ -103,9 +121,7 @@ func parse(parser *parser.Parser, piOriginal *ParseInput, jfrLabels *LabelsSnaps
 					if name == "" {
 						name = t.OsName // native threads (GC, JIT compiler, VM tasks, etc)
 					}
-					if opt.thread.Transform != nil {
-						name = opt.thread.Transform(name)
-					}
+					name = transformThreadName(name)
 					if name != "" {
 						if opt.thread.Frame {
 							correlation.ThreadName = name

--- a/pprof/parser.go
+++ b/pprof/parser.go
@@ -10,9 +10,7 @@ import (
 type pprofOptions struct {
 	truncatedFrame       bool
 	disablePanicRecovery bool
-	threadFrame          bool
-	threadLabelKey       string
-	threadLabelFn        func(threadName string) string
+	thread               ThreadInfoOptions
 }
 type Option func(*pprofOptions)
 
@@ -28,27 +26,27 @@ func WithDisablePanicRecovery(v bool) Option {
 	}
 }
 
-// WithThreadFrame, when enabled, adds the sampled thread's name as a synthetic
-// root frame beneath each execution-sample stack, so flame graphs split by the
-// thread that ran the sample. Requires the profile to have been recorded with
-// per-thread sampling. Off by default.
-func WithThreadFrame(v bool) Option {
+// ThreadInfoOptions controls how the sampled thread of each execution sample is
+// surfaced. Requires per-thread sampling (async-profiler -t). All fields optional:
+// Frame renders the thread name as a root frame; LabelKey adds a sample label
+// under that key; Transform maps the raw thread name to the value used for both
+// (e.g. collapsing to a pool name), returning "" to omit and nil to use the raw name.
+type ThreadInfoOptions struct {
+	Frame     bool
+	LabelKey  string
+	Transform func(threadName string) string
+}
+
+// WithThreadInfo surfaces the sampled thread as a root frame and/or a sample
+// label, applying a shared name transform to both. Off by default.
+func WithThreadInfo(t ThreadInfoOptions) Option {
 	return func(o *pprofOptions) {
-		o.threadFrame = v
+		o.thread = t
 	}
 }
 
-// WithThreadLabel adds a pprof sample label to each execution sample whose value
-// is derived from the sampled thread's name by fn. The caller supplies the
-// naming convention (e.g. extracting a thread-pool name via regexp), keeping
-// this package free of application-specific parsing. Requires per-thread
-// sampling. If fn returns "" for a sample, no label is added for it. A no-op
-// unless key is non-empty and fn is non-nil.
-func WithThreadLabel(key string, fn func(threadName string) string) Option {
-	return func(o *pprofOptions) {
-		o.threadLabelKey = key
-		o.threadLabelFn = fn
-	}
+func (t ThreadInfoOptions) enabled() bool {
+	return t.Frame || t.LabelKey != ""
 }
 
 func ParseJFR(body []byte, pi *ParseInput, jfrLabels *LabelsSnapshot, opts ...Option) (res *Profiles, err error) {
@@ -99,19 +97,22 @@ func parse(parser *parser.Parser, piOriginal *ParseInput, jfrLabels *LabelsSnaps
 				TraceIdHi: parser.ExecutionSample.TraceIdHi,
 				TraceIdLo: parser.ExecutionSample.TraceIdLo,
 			}
-			if opt.threadFrame || (opt.threadLabelKey != "" && opt.threadLabelFn != nil) {
+			if opt.thread.enabled() {
 				if t := parser.GetThread(parser.ExecutionSample.SampledThread); t != nil {
 					name := t.JavaName
 					if name == "" {
 						name = t.OsName // native threads (GC, JIT compiler, VM tasks, etc)
 					}
-					if opt.threadFrame {
-						correlation.ThreadName = name
+					if opt.thread.Transform != nil {
+						name = opt.thread.Transform(name)
 					}
-					if name != "" && opt.threadLabelFn != nil && opt.threadLabelKey != "" {
-						if v := opt.threadLabelFn(name); v != "" {
-							correlation.ThreadLabelKey = opt.threadLabelKey
-							correlation.ThreadLabelValue = v
+					if name != "" {
+						if opt.thread.Frame {
+							correlation.ThreadName = name
+						}
+						if opt.thread.LabelKey != "" {
+							correlation.ThreadLabelKey = opt.thread.LabelKey
+							correlation.ThreadLabelValue = name
 						}
 					}
 				}

--- a/pprof/parser.go
+++ b/pprof/parser.go
@@ -99,16 +99,11 @@ func parse(parser *parser.Parser, piOriginal *ParseInput, jfrLabels *LabelsSnaps
 				TraceIdHi: parser.ExecutionSample.TraceIdHi,
 				TraceIdLo: parser.ExecutionSample.TraceIdLo,
 			}
-			// When async-profiler runs with -t, each sample carries the thread it
-			// ran on. Managed JVM threads carry their full name in JavaName;
-			// native threads (GC, JIT compiler, VM tasks) have no JavaName and
-			// are identified only by OsName, so fall back to it. The name is used
-			// only when a thread frame or a thread label was requested.
 			if opt.threadFrame || (opt.threadLabelKey != "" && opt.threadLabelFn != nil) {
 				if t := parser.GetThread(parser.ExecutionSample.SampledThread); t != nil {
 					name := t.JavaName
 					if name == "" {
-						name = t.OsName
+						name = t.OsName // native threads (GC, JIT compiler, VM tasks, etc)
 					}
 					if opt.threadFrame {
 						correlation.ThreadName = name

--- a/pprof/parser.go
+++ b/pprof/parser.go
@@ -3,6 +3,7 @@ package pprof
 import (
 	"fmt"
 	"io"
+	"regexp"
 
 	"github.com/grafana/jfr-parser/parser"
 )
@@ -47,6 +48,26 @@ func WithThreadInfo(t ThreadInfoOptions) Option {
 
 func (t ThreadInfoOptions) enabled() bool {
 	return t.Frame || t.LabelKey != ""
+}
+
+// RegexThreadTransform builds a ThreadInfoOptions.Transform that maps a thread
+// name to the first capture group of expr (e.g. a pool name), falling back to
+// the original name when it does not match so unrelated threads stay distinct.
+// It fails if expr does not compile or has no capture group.
+func RegexThreadTransform(expr string) (func(threadName string) string, error) {
+	re, err := regexp.Compile(expr)
+	if err != nil {
+		return nil, err
+	}
+	if re.NumSubexp() < 1 {
+		return nil, fmt.Errorf("thread name regex %q has no capture group", expr)
+	}
+	return func(threadName string) string {
+		if m := re.FindStringSubmatch(threadName); len(m) > 1 && m[1] != "" {
+			return m[1]
+		}
+		return threadName
+	}, nil
 }
 
 func ParseJFR(body []byte, pi *ParseInput, jfrLabels *LabelsSnapshot, opts ...Option) (res *Profiles, err error) {

--- a/pprof/pprof.go
+++ b/pprof/pprof.go
@@ -117,6 +117,9 @@ func (b *jfrPprofBuilders) addStacktrace(sampleType int64, correlation Stacktrac
 	if b.opt.truncatedFrame && st.Truncated {
 		locations = append(locations, p.getTruncatedLocation())
 	}
+	if correlation.ThreadName != "" {
+		locations = append(locations, p.getThreadLocation(correlation.ThreadName))
+	}
 	vs := make([]int64, len(values))
 	addValues(vs)
 	p.AddExternalSampleWithLabels(locations, vs, b.contextLabels(correlation.ContextId), b.jfrLabels, uint64(ref), correlation)

--- a/pprof/profile_builder.go
+++ b/pprof/profile_builder.go
@@ -14,6 +14,7 @@ type ProfileBuilder struct {
 	metricName                    string
 
 	truncatedLoc uint64
+	threadLoc    map[string]uint64
 }
 
 type sampleID struct {
@@ -128,12 +129,13 @@ func (m *ProfileBuilder) AddExternalSampleWithLabels(locs []uint64, values []int
 	}
 	m.externalSampleID2SampleIndex[sampleID{locationsID: locationsID, correlation: correlation}] = uint32(len(m.Profile.Sample))
 	m.Profile.Sample = append(m.Profile.Sample, sample)
-	if labelsSnapshot == nil {
-		return
-	}
+	// A thread-derived label (see WithThreadLabel) is independent of the JFR
+	// label snapshot, so it must be added even when the snapshot is nil.
+	hasThreadLabel := correlation.ThreadLabelKey != "" && correlation.ThreadLabelValue != ""
 	const LabelProfileId = "profile_id"
 	const LabelSpanName = "span_name"
 	const LabelTraceId = "trace_id"
+	hasTraceId := correlation.TraceIdHi != 0 || correlation.TraceIdLo != 0
 	capacity := 0
 	if labelsCtx != nil {
 		capacity += len(labelsCtx.Labels)
@@ -144,26 +146,30 @@ func (m *ProfileBuilder) AddExternalSampleWithLabels(locs []uint64, values []int
 	if correlation.SpanName != 0 {
 		capacity++
 	}
-	if correlation.TraceIdHi != 0 || correlation.TraceIdLo != 0 {
+	if hasTraceId {
 		capacity++
 	}
-	if labelsCtx != nil {
+	if hasThreadLabel {
+		capacity++
+	}
+	if capacity > 0 {
 		sample.Label = make([]*profilev1.Label, 0, capacity)
+	}
+	if labelsCtx != nil && labelsSnapshot != nil {
 		for k, v := range labelsCtx.Labels {
 			sample.Label = append(sample.Label, &profilev1.Label{
 				Key: m.addString(labelsSnapshot.Strings[k]),
 				Str: m.addString(labelsSnapshot.Strings[v]),
 			})
 		}
-
 	}
-	if correlation.SpanId != 0 {
+	if labelsSnapshot != nil && correlation.SpanId != 0 {
 		sample.Label = append(sample.Label, &profilev1.Label{
 			Key: m.addString(LabelProfileId),
 			Str: m.addString(profileIdString(correlation.SpanId)),
 		})
 	}
-	if correlation.SpanName != 0 {
+	if labelsSnapshot != nil && correlation.SpanName != 0 {
 		spanName := labelsSnapshot.Strings[int64(correlation.SpanName)]
 		if spanName != "" {
 			sample.Label = append(sample.Label, &profilev1.Label{
@@ -172,10 +178,16 @@ func (m *ProfileBuilder) AddExternalSampleWithLabels(locs []uint64, values []int
 			})
 		}
 	}
-	if correlation.TraceIdHi != 0 || correlation.TraceIdLo != 0 {
+	if labelsSnapshot != nil && hasTraceId {
 		sample.Label = append(sample.Label, &profilev1.Label{
 			Key: m.addString(LabelTraceId),
 			Str: m.addString(traceIdString(correlation.TraceIdHi, correlation.TraceIdLo)),
+		})
+	}
+	if hasThreadLabel {
+		sample.Label = append(sample.Label, &profilev1.Label{
+			Key: m.addString(correlation.ThreadLabelKey),
+			Str: m.addString(correlation.ThreadLabelValue),
 		})
 	}
 }
@@ -198,6 +210,16 @@ type StacktraceCorrelation struct {
 	SpanName  uint64
 	TraceIdHi uint64
 	TraceIdLo uint64
+	// ThreadName, when set, is rendered as a synthetic root frame beneath the
+	// sampled stack so that samples group by the thread they ran on. It is part
+	// of the sample dedup key, so identical stacks on different threads stay
+	// distinct. Empty means no per-thread grouping (default behaviour).
+	ThreadName string
+	// ThreadLabelKey/ThreadLabelValue, when both set, add a pprof sample label
+	// derived from the thread name (see WithThreadLabel). Part of the dedup key
+	// so samples with different label values stay distinct.
+	ThreadLabelKey   string
+	ThreadLabelValue string
 }
 
 // FindExternalSampleWithLabels deprecated
@@ -223,4 +245,19 @@ func (m *ProfileBuilder) getTruncatedLocation() uint64 {
 	location := m.addLocation(f, 0)
 	m.truncatedLoc = uint64(location)
 	return m.truncatedLoc
+}
+
+// getThreadLocation returns a location for a synthetic frame naming the thread a
+// sample ran on, interning one location per distinct thread name.
+func (m *ProfileBuilder) getThreadLocation(threadName string) uint64 {
+	if m.threadLoc == nil {
+		m.threadLoc = map[string]uint64{}
+	}
+	if loc, ok := m.threadLoc[threadName]; ok {
+		return loc
+	}
+	f := m.addFunction(threadName)
+	location := uint64(m.addLocation(f, 0))
+	m.threadLoc[threadName] = location
+	return location
 }

--- a/pprof/thread_options_test.go
+++ b/pprof/thread_options_test.go
@@ -37,7 +37,7 @@ func funcNames(p *profilev1.Profile) map[string]bool {
 }
 
 // leafFunc returns the name of the last location's function in a sample, which
-// is the synthetic root frame when WithThreadFrame is enabled.
+// is the synthetic root frame when the thread frame is enabled.
 func leafFunc(p *profilev1.Profile, s *profilev1.Sample) string {
 	locID := s.LocationId[len(s.LocationId)-1]
 	for _, loc := range p.Location {
@@ -52,35 +52,47 @@ func leafFunc(p *profilev1.Profile, s *profilev1.Sample) string {
 	return ""
 }
 
-func TestWithThreadFrame(t *testing.T) {
+// poolTransform collapses per-thread names such as "http-nio-auto-1-exec-9" to
+// the pool name "http-nio-auto".
+func poolTransform(name string) string {
+	re := regexp.MustCompile(`^(.*?)-\d`)
+	if m := re.FindStringSubmatch(name); len(m) > 1 {
+		return m[1]
+	}
+	return ""
+}
+
+func TestThreadFrame(t *testing.T) {
 	// The "traceid" fixture is recorded per-thread and has a worker thread that
 	// burns cpu, so its samples carry a resolvable thread name.
 	base := cpuProfile(t, "traceid")
-	withFrame := cpuProfile(t, "traceid", WithThreadFrame(true))
+	withFrame := cpuProfile(t, "traceid", WithThreadInfo(ThreadInfoOptions{Frame: true}))
 
-	// A thread frame appears as a new root function named after a thread.
 	require.False(t, funcNames(base)["worker"], "base profile should not have a thread frame")
 	require.True(t, funcNames(withFrame)["worker"], "expected a synthetic frame for the worker thread")
 
-	// Every sample gains exactly one extra (root) location for its thread.
 	require.Greater(t, len(withFrame.Sample), 0)
 	for i, s := range withFrame.Sample {
 		require.NotEmpty(t, leafFunc(withFrame, s), "sample %d has no root frame", i)
 	}
 }
 
-func TestWithThreadLabel(t *testing.T) {
-	// Collapse per-thread names such as "http-nio-auto-1-exec-9" to the pool
-	// name "http-nio-auto" so samples aggregate by pool instead of by thread.
-	re := regexp.MustCompile(`^(.*?)-\d`)
-	pool := func(name string) string {
-		if m := re.FindStringSubmatch(name); len(m) > 1 {
-			return m[1]
-		}
-		return ""
-	}
+// TestThreadFrameTransform checks the shared transform also applies to the
+// frame, so the graph can split by pool rather than by individual thread.
+func TestThreadFrameTransform(t *testing.T) {
+	p := cpuProfile(t, "async-profiler", WithThreadInfo(ThreadInfoOptions{
+		Frame:     true,
+		Transform: poolTransform,
+	}))
+	require.True(t, funcNames(p)["http-nio-auto"], "expected a collapsed pool frame")
+	require.False(t, funcNames(p)["http-nio-auto-1-exec-9"], "raw thread name should not be a frame")
+}
 
-	p := cpuProfile(t, "async-profiler", WithThreadLabel("thread_pool", pool))
+func TestThreadLabel(t *testing.T) {
+	p := cpuProfile(t, "async-profiler", WithThreadInfo(ThreadInfoOptions{
+		LabelKey:  "thread_pool",
+		Transform: poolTransform,
+	}))
 
 	labelled := 0
 	for _, s := range p.Sample {
@@ -89,25 +101,23 @@ func TestWithThreadLabel(t *testing.T) {
 				labelled++
 				v := str(p, l.Str)
 				require.NotEmpty(t, v)
-				// The label carries the collapsed pool name, not a raw
-				// "-<n>"-suffixed thread name.
 				require.False(t, regexp.MustCompile(`-\d+$`).MatchString(v),
 					"thread_pool label %q should be collapsed", v)
 			}
 		}
 	}
 	require.Greater(t, labelled, 0, "expected some samples to carry a thread_pool label")
-
-	// A pool label must keep samples on different pools distinct rather than
-	// merging them.
 	require.True(t, hasLabelValue(p, "thread_pool", "http-nio-auto"),
 		"expected the http-nio-auto pool to be labelled")
 }
 
-// TestWithThreadLabelNoop verifies the label is opt-in: an empty key or nil fn
-// adds nothing.
-func TestWithThreadLabelNoop(t *testing.T) {
-	p := cpuProfile(t, "async-profiler", WithThreadLabel("", func(string) string { return "x" }))
+// TestThreadInfoNoop verifies it is opt-in: with neither frame nor label key,
+// nothing is added even when a transform is supplied.
+func TestThreadInfoNoop(t *testing.T) {
+	p := cpuProfile(t, "async-profiler", WithThreadInfo(ThreadInfoOptions{
+		Transform: func(string) string { return "x" },
+	}))
+	require.False(t, funcNames(p)["x"])
 	for _, s := range p.Sample {
 		for _, l := range s.Label {
 			require.NotEqual(t, "x", str(p, l.Str))

--- a/pprof/thread_options_test.go
+++ b/pprof/thread_options_test.go
@@ -125,6 +125,24 @@ func TestThreadInfoNoop(t *testing.T) {
 	}
 }
 
+// TestThreadTransformMemoized checks the transform runs once per distinct thread
+// name, not once per sample.
+func TestThreadTransformMemoized(t *testing.T) {
+	seen := map[string]int{}
+	p := cpuProfile(t, "async-profiler", WithThreadInfo(ThreadInfoOptions{
+		LabelKey: "thread_pool",
+		Transform: func(name string) string {
+			seen[name]++
+			return poolTransform(name)
+		},
+	}))
+	require.Greater(t, len(p.Sample), len(seen),
+		"expected more samples than distinct transform inputs")
+	for name, n := range seen {
+		require.Equal(t, 1, n, "transform called %d times for %q, expected once", n, name)
+	}
+}
+
 func hasLabelValue(p *profilev1.Profile, key, value string) bool {
 	for _, s := range p.Sample {
 		for _, l := range s.Label {

--- a/pprof/thread_options_test.go
+++ b/pprof/thread_options_test.go
@@ -1,0 +1,127 @@
+package pprof
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	profilev1 "github.com/grafana/pyroscope/api/gen/proto/go/google/v1"
+	"github.com/stretchr/testify/require"
+)
+
+// cpuProfile parses the given per-thread testdata file and returns its cpu
+// profile, which is where the thread options take effect.
+func cpuProfile(t *testing.T, file string, opts ...Option) *profilev1.Profile {
+	t.Helper()
+	jfr := readGzipFile(t, testdataDir+file+".jfr.gz")
+	profiles, err := ParseJFR(jfr, parseInput, nil, opts...)
+	require.NoError(t, err)
+	for _, p := range profiles.Profiles {
+		if p.Metric == "process_cpu" {
+			return p.Profile
+		}
+	}
+	t.Fatalf("no process_cpu profile in %s", file)
+	return nil
+}
+
+func str(p *profilev1.Profile, i int64) string { return p.StringTable[i] }
+
+// funcNames returns the set of function names in the profile.
+func funcNames(p *profilev1.Profile) map[string]bool {
+	names := map[string]bool{}
+	for _, f := range p.Function {
+		names[str(p, f.Name)] = true
+	}
+	return names
+}
+
+// leafFunc returns the name of the last location's function in a sample, which
+// is the synthetic root frame when WithThreadFrame is enabled.
+func leafFunc(p *profilev1.Profile, s *profilev1.Sample) string {
+	locID := s.LocationId[len(s.LocationId)-1]
+	for _, loc := range p.Location {
+		if loc.Id == locID {
+			for _, f := range p.Function {
+				if f.Id == loc.Line[0].FunctionId {
+					return str(p, f.Name)
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func TestWithThreadFrame(t *testing.T) {
+	// The "traceid" fixture is recorded per-thread and has a worker thread that
+	// burns cpu, so its samples carry a resolvable thread name.
+	base := cpuProfile(t, "traceid")
+	withFrame := cpuProfile(t, "traceid", WithThreadFrame(true))
+
+	// A thread frame appears as a new root function named after a thread.
+	require.False(t, funcNames(base)["worker"], "base profile should not have a thread frame")
+	require.True(t, funcNames(withFrame)["worker"], "expected a synthetic frame for the worker thread")
+
+	// Every sample gains exactly one extra (root) location for its thread.
+	require.Greater(t, len(withFrame.Sample), 0)
+	for i, s := range withFrame.Sample {
+		require.NotEmpty(t, leafFunc(withFrame, s), "sample %d has no root frame", i)
+	}
+}
+
+func TestWithThreadLabel(t *testing.T) {
+	// Collapse per-thread names such as "http-nio-auto-1-exec-9" to the pool
+	// name "http-nio-auto" so samples aggregate by pool instead of by thread.
+	re := regexp.MustCompile(`^(.*?)-\d`)
+	pool := func(name string) string {
+		if m := re.FindStringSubmatch(name); len(m) > 1 {
+			return m[1]
+		}
+		return ""
+	}
+
+	p := cpuProfile(t, "async-profiler", WithThreadLabel("thread_pool", pool))
+
+	labelled := 0
+	for _, s := range p.Sample {
+		for _, l := range s.Label {
+			if str(p, l.Key) == "thread_pool" {
+				labelled++
+				v := str(p, l.Str)
+				require.NotEmpty(t, v)
+				// The label carries the collapsed pool name, not a raw
+				// "-<n>"-suffixed thread name.
+				require.False(t, regexp.MustCompile(`-\d+$`).MatchString(v),
+					"thread_pool label %q should be collapsed", v)
+			}
+		}
+	}
+	require.Greater(t, labelled, 0, "expected some samples to carry a thread_pool label")
+
+	// A pool label must keep samples on different pools distinct rather than
+	// merging them.
+	require.True(t, hasLabelValue(p, "thread_pool", "http-nio-auto"),
+		"expected the http-nio-auto pool to be labelled")
+}
+
+// TestWithThreadLabelNoop verifies the label is opt-in: an empty key or nil fn
+// adds nothing.
+func TestWithThreadLabelNoop(t *testing.T) {
+	p := cpuProfile(t, "async-profiler", WithThreadLabel("", func(string) string { return "x" }))
+	for _, s := range p.Sample {
+		for _, l := range s.Label {
+			require.NotEqual(t, "x", str(p, l.Str))
+		}
+	}
+}
+
+func hasLabelValue(p *profilev1.Profile, key, value string) bool {
+	for _, s := range p.Sample {
+		for _, l := range s.Label {
+			if str(p, l.Key) == key && strings.EqualFold(str(p, l.Str), value) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/pprof/thread_options_test.go
+++ b/pprof/thread_options_test.go
@@ -55,11 +55,24 @@ func leafFunc(p *profilev1.Profile, s *profilev1.Sample) string {
 // poolTransform collapses per-thread names such as "http-nio-auto-1-exec-9" to
 // the pool name "http-nio-auto".
 func poolTransform(name string) string {
-	re := regexp.MustCompile(`^(.*?)-\d`)
-	if m := re.FindStringSubmatch(name); len(m) > 1 {
-		return m[1]
+	fn, err := RegexThreadTransform(`^(.*?)-\d`)
+	if err != nil {
+		panic(err)
 	}
-	return ""
+	return fn(name)
+}
+
+func TestRegexThreadTransform(t *testing.T) {
+	fn, err := RegexThreadTransform(`^(.*?)-\d`)
+	require.NoError(t, err)
+	require.Equal(t, "http-nio-auto", fn("http-nio-auto-1-exec-9"))
+	// No match falls back to the original name, so unrelated threads stay distinct.
+	require.Equal(t, "no_digits_here", fn("no_digits_here"))
+
+	_, err = RegexThreadTransform(`(`)
+	require.Error(t, err)
+	_, err = RegexThreadTransform(`nogroup`)
+	require.Error(t, err)
 }
 
 func TestThreadFrame(t *testing.T) {
@@ -129,15 +142,14 @@ func TestThreadInfoNoop(t *testing.T) {
 // name, not once per sample.
 func TestThreadTransformMemoized(t *testing.T) {
 	seen := map[string]int{}
-	p := cpuProfile(t, "async-profiler", WithThreadInfo(ThreadInfoOptions{
+	cpuProfile(t, "async-profiler", WithThreadInfo(ThreadInfoOptions{
 		LabelKey: "thread_pool",
 		Transform: func(name string) string {
 			seen[name]++
 			return poolTransform(name)
 		},
 	}))
-	require.Greater(t, len(p.Sample), len(seen),
-		"expected more samples than distinct transform inputs")
+	require.NotEmpty(t, seen)
 	for name, n := range seen {
 		require.Equal(t, 1, n, "transform called %d times for %q, expected once", n, name)
 	}


### PR DESCRIPTION
This pull request adds support for surfacing the sampled thread of each execution sample in Java Flight Recorder (JFR) profiles, when using async-profiler with per-thread sampling enabled (`-t`). It introduces a new `WithThreadInfo` option that allows users to add the thread name as a synthetic root frame, a sample label, or both, with optional transformation and deduplication. The implementation ensures efficient mapping and deduplication, and includes comprehensive tests for the new functionality.

**New thread info options for JFR parsing:**

* Added `ThreadInfoOptions` and the `WithThreadInfo` option to `pprof/parser.go`, allowing users to specify whether to add a thread name as a root frame, a label, and/or apply a transformation to the thread name. [[1]](diffhunk://#diff-4b2e2974da5a9f1e3291f61663f7009adc4012f81ae72ad02a257debc6c4d2deR13) [[2]](diffhunk://#diff-4b2e2974da5a9f1e3291f61663f7009adc4012f81ae72ad02a257debc6c4d2deR29-R51)
* Implemented efficient thread name transformation and memoization, ensuring the transform function is called once per distinct thread name rather than per sample.

**Integration into profile building:**

* Updated the profile builder to add synthetic root frames for threads and thread-derived labels to samples, ensuring proper deduplication and grouping by thread or thread pool. [[1]](diffhunk://#diff-91a5c0ddc898fc81c381460ce1e64bc2765af46c61994f4457b7c32bcb3e2e1cR120-R122) [[2]](diffhunk://#diff-85e37c09db219c1a708e9c93bc01ea051301eadf80703addfcb7a332bd2434daR17) [[3]](diffhunk://#diff-85e37c09db219c1a708e9c93bc01ea051301eadf80703addfcb7a332bd2434daL131-R138) [[4]](diffhunk://#diff-85e37c09db219c1a708e9c93bc01ea051301eadf80703addfcb7a332bd2434daL147-R172) [[5]](diffhunk://#diff-85e37c09db219c1a708e9c93bc01ea051301eadf80703addfcb7a332bd2434daL175-R192) [[6]](diffhunk://#diff-85e37c09db219c1a708e9c93bc01ea051301eadf80703addfcb7a332bd2434daR213-R222) [[7]](diffhunk://#diff-85e37c09db219c1a708e9c93bc01ea051301eadf80703addfcb7a332bd2434daR249-R263)

**Parser enhancements:**

* Added `GetThread` method to the `Parser` to resolve the thread a sample was taken on, supporting async-profiler's per-thread sampling.
* Updated parsing logic to populate thread info in the sample correlation structure when enabled.

**Testing:**

* Added comprehensive tests in `pprof/thread_options_test.go` to verify thread frame and label behavior, transformation, memoization, and opt-in semantics.